### PR TITLE
관심종목 / 등락률 / 실시간 급상승 / 실시간, 과거 타임라인 데이터 구분 기능 추가

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,6 +24,7 @@ function App() {
           <Routes>
             <Route path="/" element={<Login />} />
             <Route path="/trade" element={<TradePage />} />
+            <Route path="/stocks/:symbol" element={<StockLive />} />
             <Route path="/stocks/live/:symbol" element={<StockLive />} />
             <Route path="/home" element={<HomePage />} />
             <Route path="/character" element={<Character />} />

--- a/src/components/UnifiedChart.jsx
+++ b/src/components/UnifiedChart.jsx
@@ -155,22 +155,22 @@ function HistoricalChart({ symbol, onCandlesLoaded, initialYear, initialMonth, i
   };
 
   const normalizeCandles = (payload) => {
-    const { s, t, d, o, h, l, c, v } = payload || {};
-    if (s !== 'ok' || !Array.isArray(o)) return [];
-    return o.map((_, i) => {
-      const day = d?.[i];
-      let time = Number(t?.[i]);
+    const { status, timestamps, dates, opens, highs, lows, closes, volumes } = payload || {};
+    if (status !== 'ok' || !Array.isArray(opens)) return [];
+    return opens.map((_, i) => {
+      const day = dates?.[i];
+      let time = Number(timestamps?.[i]);
       if (day) {
         const [yy, mm, dd] = String(day).split('-').map(Number);
         if ([yy, mm, dd].every(Number.isFinite)) time = { year: yy, month: mm, day: dd };
       }
       return {
         time,
-        open:  Number(o[i]),
-        high:  Number(h[i]),
-        low:   Number(l[i]),
-        close: Number(c[i]),
-        volume: Number(v?.[i] ?? 0),
+        open:  Number(opens[i]),
+        high:  Number(highs[i]),
+        low:   Number(lows[i]),
+        close: Number(closes[i]),
+        volume: Number(volumes?.[i] ?? 0),
       };
     }).filter(v => v.time && [v.open, v.high, v.low, v.close].every(Number.isFinite));
   };

--- a/src/hooks/useRealtimeStocks.jsx
+++ b/src/hooks/useRealtimeStocks.jsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useCallback } from 'react';
 import axiosInstance from '../util/axiosInstance';
 
-const useRealtimeStocks = () => {
+const useRealtimeStocks = (options = {}) => {
+  const { enabled = true } = options;
   const [stocks, setStocks] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -69,8 +70,12 @@ const useRealtimeStocks = () => {
 
   // 초기 데이터 로드
   useEffect(() => {
-    fetchAllStocks();
-  }, [fetchAllStocks]);
+    if (enabled) {
+      fetchAllStocks();
+    } else {
+      setLoading(false);
+    }
+  }, [fetchAllStocks, enabled]);
 
   // 자동 갱신 비활성화 - 스케줄러가 알아서 갱신
 

--- a/src/hooks/useWatchlist.jsx
+++ b/src/hooks/useWatchlist.jsx
@@ -1,52 +1,141 @@
-import { useState, useEffect } from "react";
-import axiosInstance from "../util/axiosInstance";
+import { useState, useEffect, useCallback } from 'react';
+import axiosInstance from '../util/axiosInstance';
 
-export const useWatchlist = () => {
-  const [watchlist, setWatchlist] = useState([]);
+export const useWatchlist = (profileId) => {
+  const [watchlist, setWatchlist] = useState(new Set());
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
 
-  // 관심 종목 불러오기
-  useEffect(() => {
-    const loadWatchlist = async () => {
-      try {
-        const watchRes = await axiosInstance.get("/watchlist", { params: { user: "guest" } });
-        const warr = Array.isArray(watchRes?.data?.tickers) ? watchRes.data.tickers : [];
-        setWatchlist(warr);
-      } catch (_) { /* ignore */ }
-    };
-    loadWatchlist();
-  }, []);
-
-  const addToWatchlist = async (ticker) => {
+  // 관심종목 목록 조회
+  const fetchWatchlist = useCallback(async () => {
+    if (!profileId) return;
+    
+    setLoading(true);
+    setError(null);
+    
     try {
-      await axiosInstance.post('/watchlist/add', null, { 
-        params: { ticker, user: 'guest' } 
+      const response = await axiosInstance.get('/user/likes/list', {
+        params: { profileId },
+        withCredentials: true
       });
-      setWatchlist((prev) => Array.from(new Set([...prev, ticker])));
-    } catch (_) { /* ignore */ }
-  };
-
-  const removeFromWatchlist = async (ticker) => {
-    try {
-      await axiosInstance.delete('/watchlist/remove', { 
-        params: { ticker, user: 'guest' } 
-      });
-      setWatchlist((prev) => prev.filter(t => t !== ticker));
-    } catch (_) { /* ignore */ }
-  };
-
-  const toggleWatchlist = (ticker) => {
-    const isFav = watchlist.includes(ticker);
-    if (isFav) {
-      removeFromWatchlist(ticker);
-    } else {
-      addToWatchlist(ticker);
+      
+      if (response.data.status === 'success') {
+        setWatchlist(new Set(response.data.watchlist || []));
+      } else {
+        setError(response.data.message || '관심종목 목록을 가져올 수 없습니다');
+      }
+    } catch (err) {
+      console.error('관심종목 목록 조회 실패:', err);
+      setError('관심종목 목록을 가져올 수 없습니다');
+    } finally {
+      setLoading(false);
     }
-  };
+  }, [profileId]);
+
+  // 관심종목 추가/제거 토글
+  const toggleWatchlist = useCallback(async (stockId) => {
+    if (!profileId) return false;
+    
+    try {
+      const response = await axiosInstance.post('/user/likes/toggle', null, {
+        params: { profileId, stockId },
+        withCredentials: true
+      });
+      
+      if (response.data.status === 'success') {
+        setWatchlist(prev => {
+          const newWatchlist = new Set(prev);
+          if (response.data.isInWatchlist) {
+            newWatchlist.add(stockId);
+          } else {
+            newWatchlist.delete(stockId);
+          }
+          return newWatchlist;
+        });
+        return true;
+      } else {
+        setError(response.data.message || '관심종목 토글에 실패했습니다');
+        return false;
+      }
+    } catch (err) {
+      console.error('관심종목 토글 실패:', err);
+      setError('관심종목 토글에 실패했습니다');
+      return false;
+    }
+  }, [profileId]);
+
+  // 관심종목 여부 확인
+  const isInWatchlist = useCallback((stockId) => {
+    return watchlist.has(stockId);
+  }, [watchlist]);
+
+  // 관심종목 추가
+  const addToWatchlist = useCallback(async (stockId) => {
+    if (!profileId) return false;
+    
+    try {
+      const response = await axiosInstance.post('/user/likes/add', null, {
+        params: { profileId, stockId },
+        withCredentials: true
+      });
+      
+      if (response.data.status === 'success') {
+        setWatchlist(prev => new Set([...prev, stockId]));
+        return true;
+      } else {
+        setError(response.data.message || '관심종목 추가에 실패했습니다');
+        return false;
+      }
+    } catch (err) {
+      console.error('관심종목 추가 실패:', err);
+      setError('관심종목 추가에 실패했습니다');
+      return false;
+    }
+  }, [profileId]);
+
+  // 관심종목 제거
+  const removeFromWatchlist = useCallback(async (stockId) => {
+    if (!profileId) return false;
+    
+    try {
+      const response = await axiosInstance.delete('/user/likes/remove', {
+        params: { profileId, stockId },
+        withCredentials: true
+      });
+      
+      if (response.data.status === 'success') {
+        setWatchlist(prev => {
+          const newWatchlist = new Set(prev);
+          newWatchlist.delete(stockId);
+          return newWatchlist;
+        });
+        return true;
+      } else {
+        setError(response.data.message || '관심종목 제거에 실패했습니다');
+        return false;
+      }
+    } catch (err) {
+      console.error('관심종목 제거 실패:', err);
+      setError('관심종목 제거에 실패했습니다');
+      return false;
+    }
+  }, [profileId]);
+
+  // 프로필이 변경될 때마다 관심종목 목록 새로고침
+  useEffect(() => {
+    fetchWatchlist();
+  }, [fetchWatchlist]);
 
   return {
     watchlist,
+    loading,
+    error,
+    fetchWatchlist,
+    toggleWatchlist,
+    isInWatchlist,
     addToWatchlist,
-    removeFromWatchlist,
-    toggleWatchlist
+    removeFromWatchlist
   };
 };
+
+export default useWatchlist;

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,9 +1,10 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { ChevronRight, X, Heart, BarChart3, TrendingUp, LogIn, LogOut } from "lucide-react";
 import axiosInstance from "@/util/axiosInstance";
 import useLoginStore from "@/store/useLoginStore";
 import useConfirmLogin from "../hooks/useConfirmLogin";
+import useRealtimeStocks from "../hooks/useRealtimeStocks";
 
 const HomePage = () => {
   const navigate = useNavigate();
@@ -11,6 +12,15 @@ const HomePage = () => {
   const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
   const [profiles, setProfiles] = useState([]);
   const { email, lastProfileId, clear } = useLoginStore();
+
+  // 실시간 주식 데이터 훅 사용
+  const {
+    stocks,
+    loading: stocksLoading,
+    error: stocksError,
+    lastUpdate,
+    isUpdating
+  } = useRealtimeStocks();
 
   const [selectedProfile, setSelectedProfile] = useState({
     id: 0,
@@ -84,48 +94,19 @@ const HomePage = () => {
       });
   };
 
-  const stocks = [
-    {
-      symbol: "AAPL",
-      name: "애플",
-      price: "$238.69",
-      change: "-0.2%",
-      changeAmount: "-$0.48",
-      logo: "🍎",
-    },
-    {
-      symbol: "MMM",
-      name: "3M",
-      price: "$155.30",
-      change: "-0.1%",
-      changeAmount: "-$0.16",
-      logo: "3️⃣",
-    },
-    {
-      symbol: "NFLX",
-      name: "넷플릭스",
-      price: "$1,243.82",
-      change: "+0.8%",
-      changeAmount: "+$9.87",
-      logo: "🎬",
-    },
-    {
-      symbol: "TSLA",
-      name: "테슬라",
-      price: "$245.67",
-      change: "+2.3%",
-      changeAmount: "+$5.52",
-      logo: "🚗",
-    },
-    {
-      symbol: "NVDA",
-      name: "엔비디아",
-      price: "$456.23",
-      change: "+3.2%",
-      changeAmount: "+$14.15",
-      logo: "🎮",
-    },
-  ];
+  // 등락률 순으로 정렬된 상위 3개 주식
+  const topRisingStocks = useMemo(() => {
+    if (!stocks || stocks.length === 0) return [];
+    
+    return stocks
+      .filter(stock => stock.change && stock.changePercent) // 유효한 데이터만 필터링
+      .sort((a, b) => {
+        const changeA = parseFloat(a.change.replace('%', ''));
+        const changeB = parseFloat(b.change.replace('%', ''));
+        return changeB - changeA; // 높은 등락률순
+      })
+      .slice(0, 3); // 상위 3개만
+  }, [stocks]);
 
   const handleCreateProfile = () => {
     // Character 페이지로 이동
@@ -217,47 +198,17 @@ const HomePage = () => {
         </div>
       </div>
 
-      {/* 보유 주식 섹션 */}
+      {/* 보유 주식 섹션 - 현재는 빈 상태 */}
       <div className="bg-slate-950 px-4 py-2">
         <div className="bg-slate-800 rounded-xl p-3">
           <h3 className="text-white text-lg font-semibold mb-3">보유 주식</h3>
           <div className="space-y-2">
-            {stocks.map((stock, index) => (
-              <div key={index} className="flex items-center justify-between">
-                <div className="flex items-center gap-3">
-                  <div className="w-8 h-8 bg-gray-100 rounded-lg flex items-center justify-center text-sm overflow-hidden">
-                    <img
-                      src={`https://financialmodelingprep.com/image-stock/${stock.symbol}.png`}
-                      alt={stock.name}
-                      className="w-full h-full object-cover"
-                      onError={(e) => {
-                        e.target.style.display = "none";
-                        e.target.nextSibling.style.display = "flex";
-                      }}
-                    />
-                    <span className="text-gray-600 font-bold text-xs hidden">
-                      {stock.symbol}
-                    </span>
-                  </div>
-                  <div>
-                    <h4 className="text-white font-medium text-sm">
-                      {stock.name}
-                    </h4>
-                    <p className="text-gray-400 text-xs">{stock.symbol}</p>
-                  </div>
-                </div>
-                <div className="text-right">
-                  <p className="text-white font-semibold text-sm">
-                    {stock.price}
-                  </p>
-                  <p
-                    className={`text-xs ${stock.change.includes("+") ? "text-red-500" : "text-gray-400"}`}
-                  >
-                    {stock.change}
-                  </p>
-                </div>
-              </div>
-            ))}
+            <div className="text-center py-8">
+              <p className="text-gray-400 text-sm">보유 주식이 없습니다</p>
+              <p className="text-gray-500 text-xs mt-1">
+                주식을 구매하여 포트폴리오를 구성해보세요
+              </p>
+            </div>
           </div>
         </div>
       </div>
@@ -268,50 +219,96 @@ const HomePage = () => {
           <h3 className="text-white text-lg font-semibold mb-3">
             실시간 급상승 종목
           </h3>
-          <div className="space-y-2">
-            {stocks.slice(0, 3).map((stock, index) => (
-              <div
-                key={`trending-${index}`}
-                className="flex items-center justify-between"
-              >
-                <div className="flex items-center gap-3">
-                  <div className="w-8 h-8 bg-gray-100 rounded-lg flex items-center justify-center text-sm overflow-hidden">
-                    <img
-                      src={`https://financialmodelingprep.com/image-stock/${stock.symbol}.png`}
-                      alt={stock.name}
-                      className="w-full h-full object-cover"
-                      onError={(e) => {
-                        e.target.style.display = "none";
-                        e.target.nextSibling.style.display = "flex";
-                      }}
-                    />
-                    <span className="text-gray-600 font-bold text-xs hidden">
-                      {stock.symbol}
-                    </span>
+          {stocksLoading ? (
+            <div className="space-y-2">
+              {[...Array(3)].map((_, index) => (
+                <div key={index} className="flex items-center justify-between p-2 animate-pulse">
+                  <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 bg-slate-700 rounded-lg"></div>
+                    <div>
+                      <div className="h-4 bg-slate-700 rounded w-20 mb-1"></div>
+                      <div className="h-3 bg-slate-700 rounded w-16"></div>
+                    </div>
                   </div>
-                  <div>
-                    <h4 className="text-white font-medium text-sm">
-                      {stock.name}
-                    </h4>
-                    <p className="text-gray-400 text-xs">{stock.symbol}</p>
+                  <div className="text-right">
+                    <div className="h-4 bg-slate-700 rounded w-16 mb-1"></div>
+                    <div className="h-3 bg-slate-700 rounded w-12"></div>
                   </div>
                 </div>
-                <div className="text-right">
-                  <p className="text-white font-semibold text-sm">
-                    {stock.price}
-                  </p>
-                  <p
-                    className={`text-xs ${stock.change.includes("+") ? "text-red-500" : "text-gray-400"}`}
-                  >
-                    {stock.change}
-                  </p>
+              ))}
+            </div>
+          ) : stocksError ? (
+            <div className="text-center py-4">
+              <p className="text-red-400 text-sm">{stocksError}</p>
+            </div>
+          ) : topRisingStocks.length === 0 ? (
+            <div className="text-center py-4">
+              <p className="text-gray-400 text-sm">데이터를 불러올 수 없습니다</p>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {topRisingStocks.map((stock, index) => (
+                <div
+                  key={`trending-${stock.symbol}-${index}`}
+                  className="flex items-center justify-between"
+                >
+                  <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 bg-gray-100 rounded-lg flex items-center justify-center text-sm overflow-hidden">
+                      <img
+                        src={`https://financialmodelingprep.com/image-stock/${stock.symbol}.png`}
+                        alt={stock.name}
+                        className="w-full h-full object-cover"
+                        onError={(e) => {
+                          e.target.style.display = "none";
+                          e.target.nextSibling.style.display = "flex";
+                        }}
+                      />
+                      <span className="text-gray-600 font-bold text-xs hidden">
+                        {stock.symbol}
+                      </span>
+                    </div>
+                    <div>
+                      <h4 className="text-white font-medium text-sm">
+                        {stock.name}
+                      </h4>
+                      <p className="text-gray-400 text-xs">{stock.symbol}</p>
+                    </div>
+                  </div>
+                  <div className="text-right">
+                    <p className="text-white font-semibold text-sm">
+                      {stock.price.startsWith('$') ? stock.price : `$${stock.price}`}
+                    </p>
+                    <div className="flex items-center gap-1">
+                      <p
+                        className={`text-xs font-medium ${
+                          stock.change.includes("+")
+                            ? "text-red-500"
+                            : "text-blue-500"
+                        }`}
+                      >
+                        {stock.change}
+                      </p>
+                      <p
+                        className={`text-xs ${
+                          stock.changePercent && stock.changePercent.includes("+")
+                            ? "text-red-500"
+                            : "text-blue-500"
+                        }`}
+                      >
+                        ({stock.changePercent})
+                      </p>
+                    </div>
+                  </div>
                 </div>
-              </div>
-            ))}
-          </div>
+              ))}
+            </div>
+          )}
           {/* 더 많은 주식목록보기 버튼 */}
-          <div className="mt-3 pt-3 border-t border-gray-200">
-            <button className="w-full py-2 text-center text-red-500 text-sm font-medium hover:bg-gray-50 rounded-lg transition-colors">
+          <div className="mt-3 pt-3 border-t border-slate-600">
+            <button 
+              onClick={() => navigate('/stocks')}
+              className="w-full py-2 text-center text-red-500 text-sm font-medium hover:bg-slate-700 rounded-lg transition-colors"
+            >
               더 많은 주식목록보기
             </button>
           </div>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -21,6 +21,14 @@ const HomePage = () => {
   const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
   const [profiles, setProfiles] = useState([]);
   const { email, lastProfileId, clear } = useLoginStore();
+  const [selectedProfile, setSelectedProfile] = useState({
+    id: 0,
+    totalInvested: 0,
+    totalAssets: 0,
+    cashBalance: 0,
+    nickname: "프로필을 선택해주세요",
+    state: true,
+  });
 
   // 실시간 주식 데이터 훅 사용
   const {
@@ -31,14 +39,89 @@ const HomePage = () => {
     isUpdating
   } = useRealtimeStocks();
 
-  const [selectedProfile, setSelectedProfile] = useState({
-    id: 0,
-    totalInvested: 0,
-    totalAssets: 0,
-    cashBalance: 0,
-    nickname: "프로필을 선택해주세요",
-    state: true,
-  });
+  // 타임라인 기반 과거 모드 여부 판별 (프로필 변경/턴 변경에 반응)
+  const { currentDate } = useDateStore();
+  const isRealtime = useMemo(() => {
+    const name = String(selectedProfile?.name || '').trim();
+    const d = String(currentDate || selectedProfile?.processDate || '');
+    return name === '실시간' || d.startsWith('0000');
+  }, [selectedProfile?.name, currentDate, selectedProfile?.processDate]);
+  const isHistorical = !isRealtime;
+  const simDate = useMemo(() => {
+    if (!isHistorical) return null;
+    const d = new Date(currentDate || selectedProfile?.processDate);
+    if (Number.isNaN(d.getTime())) return null;
+    return { year: d.getUTCFullYear(), month: d.getUTCMonth() + 1, day: d.getUTCDate() };
+  }, [isHistorical, currentDate, selectedProfile?.processDate]);
+
+  // 과거 모드: 해당 날짜 기준 급상승 종목 계산 (종가 vs 전일 종가)
+  const [histTop, setHistTop] = useState([]);
+  const [histLoading, setHistLoading] = useState(false);
+  const [histError, setHistError] = useState(null);
+  const [histCache, setHistCache] = useState({}); // 날짜별 캐시
+
+  useEffect(() => {
+    if (!isHistorical) { setHistTop([]); setHistLoading(false); setHistError(null); return; }
+    
+    // 캐시 키 생성
+    const cacheKey = `${simDate?.year}-${simDate?.month}-${simDate?.day}`;
+    if (histCache[cacheKey]) {
+      setHistTop(histCache[cacheKey]);
+      setHistLoading(false);
+      return;
+    }
+    
+    const run = async () => {
+      setHistLoading(true); setHistError(null);
+      try {
+        const base = new Date(Date.UTC(simDate.year, simDate.month - 1, simDate.day));
+        const selectedEpoch = Math.floor(base.getTime() / 1000);
+        const prevEpoch = selectedEpoch - 86400;
+        const curFrom = prevEpoch;
+        const curTo = selectedEpoch + 86400 * 7;
+        const prevFrom = prevEpoch - 86400 * 7;
+        const prevTo = prevEpoch;
+        const list = Array.isArray(stocks) ? stocks : [];
+        const symbols = list.map(s => s.symbol).filter(Boolean).slice(0, 150); // 과도한 호출 방지 제한
+        const results = await Promise.allSettled(symbols.map(async (sym) => {
+          const [curRes, prevRes] = await Promise.all([
+            axiosInstance.get('/db/candles', { params: { ticker: sym, from: curFrom, to: curTo } }),
+            axiosInstance.get('/db/candles', { params: { ticker: sym, from: prevFrom, to: prevTo } }),
+          ]);
+          const curT = curRes?.value?.data?.t || curRes?.data?.t || [];
+          const curC = curRes?.value?.data?.c || curRes?.data?.c || [];
+          let currentClose = null;
+          for (let i = 0; i < curT.length; i++) { if (curT[i] >= selectedEpoch) { currentClose = curC[i]; break; } }
+          const prevT = prevRes?.value?.data?.t || prevRes?.data?.t || [];
+          const prevC = prevRes?.value?.data?.c || prevRes?.data?.c || [];
+          let prevClose = null;
+          for (let i = prevT.length - 1; i >= 0; i--) { if (prevT[i] <= prevEpoch) { prevClose = prevC[i]; break; } }
+          if (typeof currentClose !== 'number' || typeof prevClose !== 'number') return null;
+          const chg = currentClose - prevClose;
+          const pct = prevClose !== 0 ? (chg / prevClose) * 100 : 0;
+          const meta = list.find(s => s.symbol === sym) || { name: sym };
+          return {
+            symbol: sym,
+            name: meta.name || sym,
+            price: `$${currentClose.toFixed(2)}`,
+            change: `${chg >= 0 ? '+' : ''}${chg.toFixed(2)}`,
+            changePercent: `${pct >= 0 ? '+' : ''}${pct.toFixed(2)}%`,
+          };
+        }));
+        const rows = results.map(r => (r.status === 'fulfilled' ? r.value : null)).filter(Boolean);
+        rows.sort((a, b) => parseFloat(String(b.changePercent).replace('%','')) - parseFloat(String(a.changePercent).replace('%','')));
+        const top3 = rows.slice(0, 3);
+        setHistTop(top3);
+        setHistCache(prev => ({ ...prev, [cacheKey]: top3 }));
+      } catch (_) {
+        setHistTop([]); setHistError('과거 데이터 계산 실패');
+      } finally {
+        setHistLoading(false);
+      }
+    };
+    run();
+  }, [isHistorical, simDate?.year, simDate?.month, simDate?.day, stocks, selectedProfile?.id, histCache]);
+
 
   useConfirmLogin(null);
   // 초기 프로필 로드 (email / lastProfileId 가 유효할 때만 호출)
@@ -101,22 +184,35 @@ const HomePage = () => {
         console.log("프로필 선택 성공:", res.data.id);
         setSelectedProfile(profile);
         useLoginStore.setState({ lastProfileId: profile.id });
+        try {
+          localStorage.setItem("newProfile", JSON.stringify(profile));
+          if (profile?.processDate) setCurrentDate(profile.processDate);
+        } catch (_) { /* ignore */ }
+        // 프로필 변경 시 급상승 종목 즉시 재계산 트리거
+        setTimeout(() => {
+          // selectedProfile/processDate 변경과 currentDate 설정에 의해 useEffect가 재실행됨
+        }, 0);
         setTimeout(() => setIsProfileModalOpen(false), 200);
       });
   };
 
   // 등락률 순으로 정렬된 상위 3개 주식
   const topRisingStocks = useMemo(() => {
-    if (!stocks || stocks.length === 0) return [];
-
+    if (!Array.isArray(stocks) || stocks.length === 0) return [];
+    const toPct = (val) => {
+      const n = parseFloat(String(val || '').replace('%', '').replace('+',''));
+      return Number.isFinite(n) ? n : -Infinity;
+    };
     return stocks
-      .filter(stock => stock.change && stock.changePercent) // 유효한 데이터만 필터링
-      .sort((a, b) => {
-        const changeA = parseFloat(a.change.replace('%', ''));
-        const changeB = parseFloat(b.change.replace('%', ''));
-        return changeB - changeA; // 높은 등락률순
-      })
-      .slice(0, 3); // 상위 3개만
+      .map(s => ({
+        ...s,
+        price: String(s?.price ?? ''),
+        change: String(s?.change ?? ''),
+        changePercent: String(s?.changePercent ?? ''),
+      }))
+      .filter(s => s.changePercent && toPct(s.changePercent) !== -Infinity)
+      .sort((a, b) => toPct(b.changePercent) - toPct(a.changePercent))
+      .slice(0, 3);
   }, [stocks]);
 
   const handleCreateProfile = () => {
@@ -235,7 +331,7 @@ const HomePage = () => {
           <h3 className="text-white text-lg font-semibold mb-3">
             실시간 급상승 종목
           </h3>
-          {stocksLoading ? (
+          {(isHistorical ? histLoading : stocksLoading) ? (
             <div className="space-y-2">
               {[...Array(3)].map((_, index) => (
                 <div key={index} className="flex items-center justify-between p-2 animate-pulse">
@@ -253,17 +349,17 @@ const HomePage = () => {
                 </div>
               ))}
             </div>
-          ) : stocksError ? (
+          ) : (isHistorical ? histError : stocksError) ? (
             <div className="text-center py-4">
-              <p className="text-red-400 text-sm">{stocksError}</p>
+              <p className="text-red-400 text-sm">{isHistorical ? histError : stocksError}</p>
             </div>
-          ) : topRisingStocks.length === 0 ? (
+          ) : (isHistorical ? histTop.length === 0 : topRisingStocks.length === 0) ? (
             <div className="text-center py-4">
               <p className="text-gray-400 text-sm">데이터를 불러올 수 없습니다</p>
             </div>
           ) : (
             <div className="space-y-2">
-              {topRisingStocks.map((stock, index) => (
+              {(isHistorical ? histTop : topRisingStocks).map((stock, index) => (
                 <div
                   key={`trending-${stock.symbol}-${index}`}
                   className="flex items-center justify-between"
@@ -292,26 +388,26 @@ const HomePage = () => {
                   </div>
                   <div className="text-right">
                     <p className="text-white font-semibold text-sm">
-                      {stock.price.startsWith('$') ? stock.price : `$${stock.price}`}
+                      {String(stock.price).startsWith('$') ? String(stock.price) : `$${String(stock.price)}`}
                     </p>
                     <div className="flex items-center gap-1">
                       <p
                         className={`text-xs font-medium ${
-                          stock.change.includes("+")
+                          String(stock.change).includes("+")
                             ? "text-red-500"
                             : "text-blue-500"
                         }`}
                       >
-                        {stock.change}
+                        {String(stock.change)}
                       </p>
                       <p
                         className={`text-xs ${
-                          stock.changePercent && stock.changePercent.includes("+")
+                          String(stock.changePercent || '').includes("+")
                             ? "text-red-500"
                             : "text-blue-500"
                         }`}
                       >
-                        ({stock.changePercent})
+                        ({String(stock.changePercent)})
                       </p>
                     </div>
                   </div>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -17,48 +17,7 @@ import useDateStore from "@/store/useDateStore";
 
 const HomePage = () => {
   const navigate = useNavigate();
-  const [stocks, setStocks] = useState([
-    {
-      ticker: "AAPL", //response.data.stock.ticker
-      name: "애플", //response.data.stock.name
-      price: "$238.69", // 계산필요
-      change: "-0.2%", // 계산필요 (등락률)
-      changeAmount: "-$0.48", // 등락가
-      logo: "🍎", // response.data.stock.image
-    },
-    {
-      ticker: "MMM",
-      name: "3M",
-      price: "$155.30",
-      change: "-0.1%",
-      changeAmount: "-$0.16",
-      logo: "3️⃣",
-    },
-    {
-      ticker: "NFLX",
-      name: "넷플릭스",
-      price: "$1,243.82",
-      change: "+0.8%",
-      changeAmount: "+$9.87",
-      logo: "🎬",
-    },
-    {
-      ticker: "TSLA",
-      name: "테슬라",
-      price: "$245.67",
-      change: "+2.3%",
-      changeAmount: "+$5.52",
-      logo: "🚗",
-    },
-    {
-      ticker: "NVDA",
-      name: "엔비디아",
-      price: "$456.23",
-      change: "+3.2%",
-      changeAmount: "+$14.15",
-      logo: "🎮",
-    },
-  ]);
+  const [holdingStocks, setHoldingStocks] = useState([]);
   const { setCurrentDate } = useDateStore();
   const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
   const [profiles, setProfiles] = useState([]);
@@ -79,15 +38,20 @@ const HomePage = () => {
     error: stocksError,
     lastUpdate,
     isUpdating
-  } = useRealtimeStocks();
+  } = useRealtimeStocks({ enabled: true });
 
   // 타임라인 기반 과거 모드 여부 판별 (프로필 변경/턴 변경에 반응)
   const { currentDate } = useDateStore();
   const isRealtime = useMemo(() => {
-    const name = String(selectedProfile?.name || '').trim();
-    const d = String(currentDate || selectedProfile?.processDate || '');
-    return name === '실시간' || d.startsWith('0000');
-  }, [selectedProfile?.name, currentDate, selectedProfile?.processDate]);
+    // 1) 백엔드 DTO의 timelineId가 오면 그것으로 판별 (권장)
+    if (selectedProfile?.timelineId != null) {
+      return Number(selectedProfile.timelineId) === 9;
+    }
+    // 2) 마지막 백업: 기존 로직 유지(임시 호환)
+    const name = String(selectedProfile?.name || '').toLowerCase();
+    const stateRealtime = selectedProfile?.state === true;
+    return stateRealtime || name.includes('실시간');
+  }, [selectedProfile?.timelineId, selectedProfile?.name, selectedProfile?.state]);
   const isHistorical = !isRealtime;
   const simDate = useMemo(() => {
     if (!isHistorical) return null;
@@ -95,6 +59,14 @@ const HomePage = () => {
     if (Number.isNaN(d.getTime())) return null;
     return { year: d.getUTCFullYear(), month: d.getUTCMonth() + 1, day: d.getUTCDate() };
   }, [isHistorical, currentDate, selectedProfile?.processDate]);
+  const dateKey = useMemo(() => {
+    if (!isHistorical) return null;
+    const y = String(simDate?.year || '');
+    const m = String(simDate?.month || '').padStart(2, '0');
+    const d = String(simDate?.day || '').padStart(2, '0');
+    if (!y || !m || !d) return null;
+    return `${y}-${m}-${d}`;
+  }, [isHistorical, simDate?.year, simDate?.month, simDate?.day]);
 
   // 과거 모드: 해당 날짜 기준 급상승 종목 계산 (종가 vs 전일 종가)
   const [histTop, setHistTop] = useState([]);
@@ -103,12 +75,10 @@ const HomePage = () => {
   const [histCache, setHistCache] = useState({}); // 날짜별 캐시
 
   useEffect(() => {
-    if (!isHistorical) { setHistTop([]); setHistLoading(false); setHistError(null); return; }
+    if (!isHistorical || !dateKey) { setHistTop([]); setHistLoading(false); setHistError(null); return; }
 
-    // 캐시 키 생성
-    const cacheKey = `${simDate?.year}-${simDate?.month}-${simDate?.day}`;
-    if (histCache[cacheKey]) {
-      setHistTop(histCache[cacheKey]);
+    if (histCache[dateKey]) {
+      setHistTop(histCache[dateKey]);
       setHistLoading(false);
       return;
     }
@@ -116,45 +86,10 @@ const HomePage = () => {
     const run = async () => {
       setHistLoading(true); setHistError(null);
       try {
-        const base = new Date(Date.UTC(simDate.year, simDate.month - 1, simDate.day));
-        const selectedEpoch = Math.floor(base.getTime() / 1000);
-        const prevEpoch = selectedEpoch - 86400;
-        const curFrom = prevEpoch;
-        const curTo = selectedEpoch + 86400 * 7;
-        const prevFrom = prevEpoch - 86400 * 7;
-        const prevTo = prevEpoch;
-        const list = Array.isArray(stocks) ? stocks : [];
-        const symbols = list.map(s => s.symbol).filter(Boolean).slice(0, 150); // 과도한 호출 방지 제한
-        const results = await Promise.allSettled(symbols.map(async (sym) => {
-          const [curRes, prevRes] = await Promise.all([
-            axiosInstance.get('/db/candles', { params: { ticker: sym, from: curFrom, to: curTo } }),
-            axiosInstance.get('/db/candles', { params: { ticker: sym, from: prevFrom, to: prevTo } }),
-          ]);
-          const curT = curRes?.value?.data?.t || curRes?.data?.t || [];
-          const curC = curRes?.value?.data?.c || curRes?.data?.c || [];
-          let currentClose = null;
-          for (let i = 0; i < curT.length; i++) { if (curT[i] >= selectedEpoch) { currentClose = curC[i]; break; } }
-          const prevT = prevRes?.value?.data?.t || prevRes?.data?.t || [];
-          const prevC = prevRes?.value?.data?.c || prevRes?.data?.c || [];
-          let prevClose = null;
-          for (let i = prevT.length - 1; i >= 0; i--) { if (prevT[i] <= prevEpoch) { prevClose = prevC[i]; break; } }
-          if (typeof currentClose !== 'number' || typeof prevClose !== 'number') return null;
-          const chg = currentClose - prevClose;
-          const pct = prevClose !== 0 ? (chg / prevClose) * 100 : 0;
-          const meta = list.find(s => s.symbol === sym) || { name: sym };
-          return {
-            symbol: sym,
-            name: meta.name || sym,
-            price: `$${currentClose.toFixed(2)}`,
-            change: `${chg >= 0 ? '+' : ''}${chg.toFixed(2)}`,
-            changePercent: `${pct >= 0 ? '+' : ''}${pct.toFixed(2)}%`,
-          };
-        }));
-        const rows = results.map(r => (r.status === 'fulfilled' ? r.value : null)).filter(Boolean);
-        rows.sort((a, b) => parseFloat(String(b.changePercent).replace('%','')) - parseFloat(String(a.changePercent).replace('%','')));
-        const top3 = rows.slice(0, 3);
-        setHistTop(top3);
-        setHistCache(prev => ({ ...prev, [cacheKey]: top3 }));
+        const resp = await axiosInstance.get('/db/snapshot', { params: { date: dateKey, page: 1, size: 3, sort: 'changePercent,desc' } });
+        const rows = Array.isArray(resp?.data?.rows) ? resp.data.rows : [];
+        setHistTop(rows);
+        setHistCache(prev => ({ ...prev, [dateKey]: rows }));
       } catch (_) {
         setHistTop([]); setHistError('과거 데이터 계산 실패');
       } finally {
@@ -162,7 +97,7 @@ const HomePage = () => {
       }
     };
     run();
-  }, [isHistorical, simDate?.year, simDate?.month, simDate?.day, stocks, selectedProfile?.id, histCache]);
+  }, [isHistorical, dateKey, histCache]);
 
 
   useConfirmLogin(null);
@@ -173,7 +108,7 @@ const HomePage = () => {
       const stcokList = await fetchStocks();
       // lastProfileId 가 유효하면 해당 프로필 조회, 아니면 첫 번째 프로필로 세팅
       if (lastProfileId && Number(lastProfileId) > 0) {
-        setStocks(stcokList);
+        setHoldingStocks(stcokList);
         try {
           const response = await axiosInstance.get(
             `userprofile/profile/${lastProfileId}`,
@@ -221,8 +156,7 @@ const HomePage = () => {
         { withCredentials: true }
       );
       const stockList = response.data || [];
-
-      setStocks(stockList);
+      setHoldingStocks(stockList);
       return stockList;
     } catch (error) {
       console.error("Error fetching profiles:", error);
@@ -380,7 +314,7 @@ const HomePage = () => {
         <div className="bg-slate-800 rounded-xl p-3">
           <h3 className="text-white text-lg font-semibold mb-3">보유 주식</h3>
           <div className="space-y-2">
-            {stocks.map((stock, index) => (
+            {holdingStocks.map((stock, index) => (
               <div key={index} className="flex items-center justify-between">
                 <div className="flex items-center gap-3">
                   <div className="w-8 h-8 bg-gray-100 rounded-lg flex items-center justify-center text-sm overflow-hidden">
@@ -448,7 +382,7 @@ const HomePage = () => {
             </div>
           ) : (isHistorical ? histTop.length === 0 : topRisingStocks.length === 0) ? (
             <div className="text-center py-4">
-              <p className="text-gray-400 text-sm">데이터를 불러올 수 없습니다</p>
+              <p className="text-gray-400 text-sm">{isHistorical ? '데이터를 불러올 수 없습니다' : '실시간 데이터 준비중'}</p>
             </div>
           ) : (
             <div className="space-y-2">

--- a/src/pages/Stocks.jsx
+++ b/src/pages/Stocks.jsx
@@ -21,24 +21,40 @@ const Stocks = () => {
 	const profile = useMemo(() => {
 		try { return JSON.parse(localStorage.getItem("newProfile") || "null"); } catch (_) { return null; }
 	}, [lastProfileId]);
+	// 실시간 여부: 백엔드 DTO의 timelineId 기준(실시간=9)
+	const isRealtime = useMemo(() => {
+		if (profile?.timelineId != null) {
+			return Number(profile.timelineId) === 9;
+		}
+		return false;
+	}, [profile?.timelineId]);
+
+	const isHistorical = !isRealtime;
 	const timelineFrom = profile?.timelineFrom || null;
 	const simDate = useMemo(() => {
+		if (!isHistorical) return null;
 		// currentDate가 있으면 우선 사용 (턴 종료로 날짜가 변경된 경우)
 		const dateToUse = currentDate || timelineFrom;
 		if (!dateToUse) return null;
 		const d = new Date(dateToUse);
 		if (Number.isNaN(d.getTime())) return null;
 		return { year: d.getUTCFullYear(), month: d.getUTCMonth() + 1, day: d.getUTCDate() };
-	}, [currentDate, timelineFrom, lastProfileId]);
-	const isHistorical = Boolean(simDate?.year && simDate?.month && simDate?.day);
+	}, [isHistorical, currentDate, timelineFrom, lastProfileId]);
+    const dateKey = useMemo(() => {
+	        if (!isHistorical) return null;
+        const y = String(simDate.year);
+        const m = String(simDate.month).padStart(2, '0');
+        const d = String(simDate.day).padStart(2, '0');
+        return `${y}-${m}-${d}`;
+    }, [isHistorical, simDate?.year, simDate?.month, simDate?.day]);
 
 	// 실시간 주식 데이터 훅 사용
-	const {
-		stocks,
-		loading,
-		error,
-		lastUpdate
-	} = useRealtimeStocks();
+    const {
+        stocks,
+        loading,
+        error,
+        lastUpdate
+	    } = useRealtimeStocks({ enabled: !isHistorical });
 
 	// 관심종목 훅 사용
 	const {
@@ -49,6 +65,11 @@ const Stocks = () => {
 		isInWatchlist
 	} = useWatchlist(lastProfileId);
 
+	// 과거 모드 관심종목 rows (스냅샷 기반)
+	const [histFavRows, setHistFavRows] = useState([]);
+	const [histFavLoading, setHistFavLoading] = useState(false);
+	const [histFavError, setHistFavError] = useState(null);
+
 	// 과거 모드 가격 캐시
 	const [histMap, setHistMap] = useState({}); // symbol -> { price, change, changePercent }
 
@@ -56,6 +77,7 @@ const Stocks = () => {
 	useEffect(() => {
 		if (isHistorical) {
 			setHistMap({});
+			setHistFavRows([]);
 		}
 	}, [simDate?.year, simDate?.month, simDate?.day, isHistorical]);
 
@@ -81,15 +103,20 @@ const Stocks = () => {
 	};
 
 	// 주식 표시 데이터 계산 함수
-	const getStockDisplayData = (stock) => {
-		const hp = isHistorical ? histMap[stock.symbol] : null;
-		const priceText = isHistorical ? (hp?.price ?? '-') : (String(stock.price).startsWith('$') ? String(stock.price) : `$${String(stock.price)}`);
-		const changeText = isHistorical ? (hp?.change ?? '-') : String(stock.change ?? '');
-		const changePctText = isHistorical ? (hp?.changePercent ?? '-') : String(stock.changePercent ?? '');
-		const isUp = (isHistorical ? String(hp?.change || '').startsWith('+') : String(stock.change ?? '').includes("+"));
-		
-		return { priceText, changeText, changePctText, isUp };
-	};
+    const getStockDisplayData = (stock) => {
+        if (isHistorical) {
+            const priceText = String(stock?.price ?? '-');
+            const changeText = String(stock?.change ?? '-');
+            const changePctText = String(stock?.changePercent ?? '-');
+            const isUp = changeText.startsWith('+');
+            return { priceText, changeText, changePctText, isUp };
+        }
+        const priceText = (String(stock.price).startsWith('$') ? String(stock.price) : `$${String(stock.price)}`);
+        const changeText = String(stock.change ?? '');
+        const changePctText = String(stock.changePercent ?? '');
+        const isUp = String(stock.change ?? '').includes("+");
+        return { priceText, changeText, changePctText, isUp };
+    };
 
 	// 주식 카드 컴포넌트
 	const StockCard = ({ stock, index, showFavorite = true }) => {
@@ -126,7 +153,7 @@ const Stocks = () => {
 						<p className="text-white font-semibold text-lg">
 							{priceText}
 						</p>
-						<div className="flex items-center gap-1">
+                            <div className="flex items-center gap-1">
 							<p className={`text-sm font-medium ${isUp ? "text-red-500" : "text-blue-500"}`}>
 								{changeText}
 							</p>
@@ -159,34 +186,30 @@ const Stocks = () => {
 	};
 
 	// 필터링된 주식 목록
-	const filteredStocks = useMemo(() => {
-		let filtered = stocks.filter(
-			(stock) =>
-				stock.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-				stock.symbol.toLowerCase().includes(searchQuery.toLowerCase())
-		);
+    const filteredStocks = useMemo(() => {
+        const base = isHistorical ? (histMap.__rows || []) : stocks;
+        const q = String(searchQuery || '').toLowerCase();
+        let filtered = base.filter((stock) => {
+            const name = String(stock?.name || '').toLowerCase();
+            const sym = String(stock?.symbol || '').toLowerCase();
+            return name.includes(q) || sym.includes(q);
+        });
 
 		// 정렬 적용 (표시값 기준 정렬: 과거 모드라면 histMap 값이 있으면 그 값으로)
-		switch (selectedFilter) {
-			case "이름":
-				filtered.sort((a, b) => a.name.localeCompare(b.name));
-				break;
-			case "가격":
-				filtered.sort((a, b) => {
-					const normalizePrice = (val) => parseFloat(String(val ?? '').replace('$', '').replace(',', '')) || 0;
-					const pa = isHistorical ? normalizePrice(histMap[a.symbol]?.price) : normalizePrice(a.price);
-					const pb = isHistorical ? normalizePrice(histMap[b.symbol]?.price) : normalizePrice(b.price);
-					return pb - pa;
-				});
-				break;
-			case "등락률":
-				filtered.sort((a, b) => {
-					const normalizePercent = (val) => parseFloat(String(val ?? '0').replace('%', '')) || 0;
-					const ca = isHistorical ? normalizePercent(histMap[a.symbol]?.changePercent) : normalizePercent(a.change);
-					const cb = isHistorical ? normalizePercent(histMap[b.symbol]?.changePercent) : normalizePercent(b.change);
-					return cb - ca;
-				});
-				break;
+        switch (selectedFilter) {
+            case "이름":
+                if (!isHistorical) filtered.sort((a, b) => a.name.localeCompare(b.name));
+                break;
+            case "등락률":
+                if (!isHistorical) {
+                    filtered.sort((a, b) => {
+                        const normalizePercent = (val) => parseFloat(String(val ?? '0').replace('%', '')) || 0;
+                        const ca = normalizePercent(a.change);
+                        const cb = normalizePercent(b.change);
+                        return cb - ca;
+                    });
+                }
+                break;
 			default:
 				break;
 		}
@@ -194,63 +217,51 @@ const Stocks = () => {
 		return filtered;
 	}, [stocks, searchQuery, selectedFilter, isHistorical, histMap]);
 
-	// 페이지네이션 계산
-	const totalPages = Math.ceil(filteredStocks.length / stocksPerPage);
-	const startIndex = (currentPage - 1) * stocksPerPage;
-	const endIndex = startIndex + stocksPerPage;
-	const currentStocks = filteredStocks.slice(startIndex, endIndex);
+    // 페이지네이션 계산 (실시간: 클라이언트, 과거: 서버에서 페이지 반환 사용)
+    const totalPages = useMemo(() => {
+        if (isHistorical) {
+            const total = Number(histMap.__total || 0);
+            return total > 0 ? Math.ceil(total / stocksPerPage) : 1;
+        }
+        return Math.ceil(filteredStocks.length / stocksPerPage);
+    }, [isHistorical, histMap.__total, filteredStocks.length, stocksPerPage]);
 
-	// 현재 페이지 심볼들의 과거 가격 로드 트리거
+    const startIndex = (currentPage - 1) * stocksPerPage;
+    const endIndex = startIndex + stocksPerPage;
+    const currentStocks = isHistorical ? (histMap.__rows || []) : filteredStocks.slice(startIndex, endIndex);
+
+    // 과거 모드: 서버 페이징 스냅샷 로드 (정렬 서버 위임)
 	useEffect(() => {
-		if (!isHistorical || !simDate) return;
-		const symbols = currentStocks.map(s => s.symbol).filter(Boolean);
-		if (symbols.length === 0) return;
-		
-		// 이미 캐시된 심볼들은 제외
-		const uncachedSymbols = symbols.filter(sym => !histMap[sym]);
-		if (uncachedSymbols.length === 0) return;
-		
-		const doFetch = async () => {
-			const base = new Date(Date.UTC(simDate.year, simDate.month - 1, simDate.day));
-			const selectedEpoch = Math.floor(base.getTime() / 1000);
-			const prevEpoch = selectedEpoch - 86400;
-			const curFrom = prevEpoch;
-			const curTo = selectedEpoch + 86400 * 7;
-			const prevFrom = prevEpoch - 86400 * 7;
-			const prevTo = prevEpoch;
-			const updates = {};
-			
-			await Promise.all(uncachedSymbols.map(async (sym) => {
-				try {
-					const [curRes, prevRes] = await Promise.all([
-						axios.get('/db/candles', { params: { ticker: sym, from: curFrom, to: curTo } }),
-						axios.get('/db/candles', { params: { ticker: sym, from: prevFrom, to: prevTo } }),
-					]);
-					const curT = curRes?.data?.t || [];
-					const curC = curRes?.data?.c || [];
-					let currentClose = null;
-					for (let i = 0; i < curT.length; i++) { if (curT[i] >= selectedEpoch) { currentClose = curC[i]; break; } }
-					const prevT = prevRes?.data?.t || [];
-					const prevC = prevRes?.data?.c || [];
-					let prevClose = null;
-					for (let i = prevT.length - 1; i >= 0; i--) { if (prevT[i] <= prevEpoch) { prevClose = prevC[i]; break; } }
-					if (typeof currentClose === 'number' && typeof prevClose === 'number') {
-						const chg = currentClose - prevClose;
-						const pct = prevClose !== 0 ? (chg / prevClose) * 100 : 0;
-						updates[sym] = { price: `$${currentClose.toFixed(2)}`, change: `${chg >= 0 ? '+' : ''}${chg.toFixed(2)}`, changePercent: `${pct >= 0 ? '+' : ''}${pct.toFixed(2)}%` };
-					} else {
-						updates[sym] = { price: '-', change: '-', changePercent: '-' };
-					}
-				} catch (_) {
-					updates[sym] = { price: '-', change: '-', changePercent: '-' };
-				}
-			}));
-			
-			if (Object.keys(updates).length > 0) setHistMap((prev) => ({ ...prev, ...updates }));
-		};
-		
-		doFetch();
-	}, [currentStocks, isHistorical, simDate?.year, simDate?.month, simDate?.day, histMap]);
+        if (!isHistorical || !simDate) return;
+        const doFetch = async () => {
+            try {
+                const sort = selectedFilter === '등락률' ? 'changePercent,desc' : 'name,asc';
+                const resp = await axios.get('/db/snapshot', { params: { date: dateKey, page: currentPage, size: stocksPerPage, sort } });
+                const arr = Array.isArray(resp?.data?.rows) ? resp.data.rows : [];
+                const total = Number(resp?.data?.total || 0);
+                const projection = { __rows: arr, __total: total };
+                setHistMap(projection);
+            } catch (_) {
+                // 폴백: 기존 방식(부분 페치) 유지
+            }
+        };
+        doFetch();
+    }, [isHistorical, simDate?.year, simDate?.month, simDate?.day, dateKey, currentPage, selectedFilter, stocksPerPage]);
+
+	// 과거 모드: 관심종목 스냅샷 로드 (symbols 파라미터 사용)
+	useEffect(() => {
+		if (!isHistorical || !dateKey) return;
+		if (!(watchlist && watchlist.size)) { setHistFavRows([]); setHistFavError(null); setHistFavLoading(false); return; }
+		const symbolsCsv = Array.from(watchlist).join(',');
+		setHistFavLoading(true); setHistFavError(null);
+		axios.get('/db/snapshot', { params: { date: dateKey, symbols: symbolsCsv, sort: 'name,asc', page: 1, size: 1000 } })
+			.then((resp) => {
+				const rows = Array.isArray(resp?.data?.rows) ? resp.data.rows : [];
+				setHistFavRows(rows);
+			})
+			.catch(() => setHistFavError('관심종목 불러오기 실패'))
+			.finally(() => setHistFavLoading(false));
+	}, [isHistorical, dateKey, watchlist]);
 
 	// 검색어 변경 시 첫 페이지로 이동
 	useEffect(() => {
@@ -276,7 +287,7 @@ const Stocks = () => {
 				{/* 페이지 제목 */}
 				<div className="px-4 py-2">
 					<div className="flex items-center justify-between">
-						<div className="flex items-center gap-4 text-xs text-gray-400 mt-1">
+                                <div className="flex items-center gap-4 text-xs text-gray-400 mt-1">
 							{lastUpdate && (
 								<div className="flex items-center gap-1">
 									<Clock className="w-3 h-3" />
@@ -284,13 +295,8 @@ const Stocks = () => {
 								</div>
 							)}
 							<div className="flex items-center gap-1">
-								<span>총 {stocks.length}개 주식</span>
-								{filteredStocks.length !== stocks.length && (
-									<span>(검색 결과: {filteredStocks.length}개)</span>
-								)}
-								{filteredStocks.length > stocksPerPage && (
-									<span>(페이지 {currentPage}/{totalPages})</span>
-								)}
+                                        <span>총 {isHistorical ? (histMap.__total || 0) : stocks.length}개 주식</span>
+                                        <span>(페이지 {currentPage}/{totalPages})</span>
 							</div>
 						</div>
 					</div>
@@ -342,8 +348,8 @@ const Stocks = () => {
 
 						{/* 정렬 옵션 */}
 						<div className="px-4 py-2">
-							<div className="flex gap-2">
-								{["이름", "가격", "등락률"].map((option) => (
+                            <div className="flex gap-2">
+                                {["이름", "등락률"].map((option) => (
 									<button
 										key={option}
 										onClick={() => setSelectedFilter(option)}
@@ -407,12 +413,22 @@ const Stocks = () => {
 								</div>
 							)}
 
-							{/* 페이지네이션 */}
-							{filteredStocks.length > stocksPerPage && (
+                            {/* 페이지네이션 */}
+                            {(isHistorical ? (totalPages > 1) : (filteredStocks.length > stocksPerPage)) && (
 								<div className="mt-6 flex items-center justify-between">
-									<div className="text-sm text-gray-400">
-										{startIndex + 1}-{Math.min(endIndex, filteredStocks.length)} / {filteredStocks.length}개
-									</div>
+                                    <div className="text-sm text-gray-400">
+                                        {isHistorical
+                                            ? ((currentPage - 1) * stocksPerPage + 1)
+                                            : (startIndex + 1)
+                                        }
+                                        -
+                                        {isHistorical
+                                            ? Math.min(currentPage * stocksPerPage, Number(histMap.__total || 0))
+                                            : Math.min(endIndex, filteredStocks.length)
+                                        }
+                                        
+                                        / {isHistorical ? Number(histMap.__total || 0) : filteredStocks.length}개
+                                    </div>
 									<div className="flex items-center gap-2">
 										<button onClick={() => setCurrentPage(prev => Math.max(1, prev - 1))} disabled={currentPage === 1} className={`px-3 py-1 rounded-md text-sm ${currentPage === 1 ? 'bg-gray-700 text-gray-500 cursor-not-allowed' : 'bg-slate-700 text-white hover:bg-slate-600'}`}>이전</button>
 										<span className="text-sm text-gray-400">{currentPage} / {totalPages}</span>
@@ -440,9 +456,9 @@ const Stocks = () => {
 								</div>
 							</div>
 						)}
-						
+
 						<div className="space-y-2">
-							{watchlistLoading ? (
+							{(watchlistLoading || (isHistorical && histFavLoading)) ? (
 								<div className="space-y-2">
 									{[...Array(3)].map((_, index) => (
 										<div key={index} className="flex items-center justify-between p-3 bg-slate-800 rounded-xl animate-pulse">
@@ -472,8 +488,7 @@ const Stocks = () => {
 									</p>
 								</div>
 							) : (
-								stocks
-									.filter((stock) => isInWatchlist(stock.symbol))
+								(isHistorical ? histFavRows : stocks.filter((stock) => isInWatchlist(stock.symbol)))
 									.map((stock, index) => (
 										<StockCard key={index} stock={stock} index={index} showFavorite={true} />
 									))

--- a/src/pages/Stocks.jsx
+++ b/src/pages/Stocks.jsx
@@ -3,6 +3,8 @@ import { useNavigate } from "react-router-dom";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogClose } from "@/components/ui/dialog";
 import { ChevronLeft, Search, X, Heart, AlertCircle, Clock } from "lucide-react";
 import useRealtimeStocks from "../hooks/useRealtimeStocks";
+import useWatchlist from "../hooks/useWatchlist";
+import useLoginStore from "../store/useLoginStore";
 
 const Stocks = () => {
   const navigate = useNavigate();
@@ -10,9 +12,11 @@ const Stocks = () => {
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedFilter, setSelectedFilter] = useState("이름");
   const [selectedStocks, setSelectedStocks] = useState([]);
-  const [favoriteStocks, setFavoriteStocks] = useState(new Set());
   const [currentPage, setCurrentPage] = useState(1);
   const [stocksPerPage] = useState(6); // 페이지당 6개 주식 표시
+
+  // 로그인 상태 및 프로필 정보
+  const { lastProfileId } = useLoginStore();
 
   // 실시간 주식 데이터 훅 사용
   const {
@@ -22,6 +26,15 @@ const Stocks = () => {
     lastUpdate,
     isUpdating
   } = useRealtimeStocks();
+
+  // 관심종목 훅 사용
+  const {
+    watchlist,
+    loading: watchlistLoading,
+    error: watchlistError,
+    toggleWatchlist,
+    isInWatchlist
+  } = useWatchlist(lastProfileId);
 
   const newsItems = [
     {
@@ -114,16 +127,16 @@ const Stocks = () => {
     setSelectedStocks(selectedStocks.filter((s) => s.symbol !== symbol));
   };
 
-  const toggleFavorite = (symbol) => {
-    setFavoriteStocks((prev) => {
-      const newFavorites = new Set(prev);
-      if (newFavorites.has(symbol)) {
-        newFavorites.delete(symbol);
-      } else {
-        newFavorites.add(symbol);
-      }
-      return newFavorites;
-    });
+  const handleToggleFavorite = async (symbol) => {
+    if (!lastProfileId) {
+      alert('로그인이 필요합니다');
+      return;
+    }
+    
+    const success = await toggleWatchlist(symbol);
+    if (!success) {
+      alert('관심종목 토글에 실패했습니다');
+    }
   };
 
   // 필터링된 주식 목록
@@ -469,13 +482,14 @@ const Stocks = () => {
                       <button
                         onClick={(e) => {
                           e.stopPropagation();
-                          toggleFavorite(stock.symbol);
+                          handleToggleFavorite(stock.symbol);
                         }}
                         className="p-1 hover:bg-slate-600 rounded-full transition-colors"
+                        disabled={watchlistLoading}
                       >
                         <Heart
                           className={`w-5 h-5 ${
-                            favoriteStocks.has(stock.symbol)
+                            isInWatchlist(stock.symbol)
                               ? "text-red-500 fill-red-500"
                               : "text-gray-400"
                           }`}
@@ -536,8 +550,38 @@ const Stocks = () => {
         ) : (
           /* 관심종목 목록 */
           <div className="px-4 py-2">
+            {watchlistError && (
+              <div className="mb-4 p-3 bg-red-900/20 border border-red-500/30 rounded-lg">
+                <div className="flex items-center gap-2 text-red-400">
+                  <AlertCircle className="w-4 h-4" />
+                  <span className="text-sm">{watchlistError}</span>
+                </div>
+              </div>
+            )}
+            
             <div className="space-y-2">
-              {favoriteStocks.size === 0 ? (
+              {watchlistLoading ? (
+                <div className="space-y-2">
+                  {[...Array(3)].map((_, index) => (
+                    <div key={index} className="flex items-center justify-between p-3 bg-slate-800 rounded-xl animate-pulse">
+                      <div className="flex items-center gap-3">
+                        <div className="w-10 h-10 bg-slate-700 rounded-lg"></div>
+                        <div>
+                          <div className="h-4 bg-slate-700 rounded w-20 mb-2"></div>
+                          <div className="h-3 bg-slate-700 rounded w-16"></div>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-3">
+                        <div className="text-right">
+                          <div className="h-4 bg-slate-700 rounded w-16 mb-2"></div>
+                          <div className="h-3 bg-slate-700 rounded w-12"></div>
+                        </div>
+                        <div className="w-6 h-6 bg-slate-700 rounded-full"></div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : watchlist.size === 0 ? (
                 <div className="text-center py-8">
                   <Heart className="w-12 h-12 text-gray-400 mx-auto mb-4" />
                   <p className="text-gray-400 text-sm">관심종목이 없습니다</p>
@@ -547,11 +591,12 @@ const Stocks = () => {
                 </div>
               ) : (
                 stocks
-                  .filter((stock) => favoriteStocks.has(stock.symbol))
+                  .filter((stock) => isInWatchlist(stock.symbol))
                   .map((stock, index) => (
                     <div
                       key={index}
                       className="flex items-center justify-between p-3 bg-slate-800 rounded-xl cursor-pointer hover:bg-slate-700 transition-colors"
+                      onClick={() => handleStockSelect(stock)}
                     >
                       <div className="flex items-center gap-3">
                         <div className="w-10 h-10 bg-gray-100 rounded-lg flex items-center justify-center text-lg overflow-hidden">
@@ -594,7 +639,7 @@ const Stocks = () => {
                             </p>
                             <p
                               className={`text-xs ${
-                                stock.changePercent.includes("+")
+                                stock.changePercent && stock.changePercent.includes("+")
                                   ? "text-red-500"
                                   : "text-blue-500"
                               }`}
@@ -604,8 +649,12 @@ const Stocks = () => {
                           </div>
                         </div>
                         <button
-                          onClick={() => toggleFavorite(stock.symbol)}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleToggleFavorite(stock.symbol);
+                          }}
                           className="p-1 hover:bg-slate-600 rounded-full transition-colors"
+                          disabled={watchlistLoading}
                         >
                           <Heart className="w-5 h-5 text-red-500 fill-red-500" />
                         </button>

--- a/src/pages/Stocks.jsx
+++ b/src/pages/Stocks.jsx
@@ -1,673 +1,489 @@
 import React, { useMemo, useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogClose } from "@/components/ui/dialog";
 import { ChevronLeft, Search, X, Heart, AlertCircle, Clock } from "lucide-react";
 import useRealtimeStocks from "../hooks/useRealtimeStocks";
 import useWatchlist from "../hooks/useWatchlist";
 import useLoginStore from "../store/useLoginStore";
+import useDateStore from "../store/useDateStore";
+import axios from "../util/axiosInstance";
 
 const Stocks = () => {
-  const navigate = useNavigate();
-  const [activeTab, setActiveTab] = useState("탐색");
-  const [searchQuery, setSearchQuery] = useState("");
-  const [selectedFilter, setSelectedFilter] = useState("이름");
-  const [selectedStocks, setSelectedStocks] = useState([]);
-  const [currentPage, setCurrentPage] = useState(1);
-  const [stocksPerPage] = useState(6); // 페이지당 6개 주식 표시
+   const navigate = useNavigate();
+   const [activeTab, setActiveTab] = useState("탐색");
+   const [searchQuery, setSearchQuery] = useState("");
+   const [selectedFilter, setSelectedFilter] = useState("이름");
+   const [currentPage, setCurrentPage] = useState(1);
+   const [stocksPerPage] = useState(6); // 페이지당 6개 주식 표시
 
-  // 로그인 상태 및 프로필 정보
-  const { lastProfileId } = useLoginStore();
+	// 로그인 상태 및 프로필 정보
+	const { lastProfileId } = useLoginStore();
+	const { currentDate } = useDateStore();
+	const profile = useMemo(() => {
+		try { return JSON.parse(localStorage.getItem("newProfile") || "null"); } catch (_) { return null; }
+	}, [lastProfileId]);
+	const timelineFrom = profile?.timelineFrom || null;
+	const simDate = useMemo(() => {
+		// currentDate가 있으면 우선 사용 (턴 종료로 날짜가 변경된 경우)
+		const dateToUse = currentDate || timelineFrom;
+		if (!dateToUse) return null;
+		const d = new Date(dateToUse);
+		if (Number.isNaN(d.getTime())) return null;
+		return { year: d.getUTCFullYear(), month: d.getUTCMonth() + 1, day: d.getUTCDate() };
+	}, [currentDate, timelineFrom, lastProfileId]);
+	const isHistorical = Boolean(simDate?.year && simDate?.month && simDate?.day);
 
-  // 실시간 주식 데이터 훅 사용
-  const {
-    stocks,
-    loading,
-    error,
-    lastUpdate,
-    isUpdating
-  } = useRealtimeStocks();
+	// 실시간 주식 데이터 훅 사용
+	const {
+		stocks,
+		loading,
+		error,
+		lastUpdate
+	} = useRealtimeStocks();
 
-  // 관심종목 훅 사용
-  const {
-    watchlist,
-    loading: watchlistLoading,
-    error: watchlistError,
-    toggleWatchlist,
-    isInWatchlist
-  } = useWatchlist(lastProfileId);
+	// 관심종목 훅 사용
+	const {
+		watchlist,
+		loading: watchlistLoading,
+		error: watchlistError,
+		toggleWatchlist,
+		isInWatchlist
+	} = useWatchlist(lastProfileId);
 
-  const newsItems = [
-    {
-      id: 1,
-      symbol: "FIG",
-      change: "+0.09%",
-      changeColor: "text-red-500",
-      headline:
-        "캐시 우드의 아크 인베스트, 실적 발표 후 20% 하락 속에서 피그마 주식 매입",
-      source: "Decrypt.co",
-      timestamp: "2025-09-05 09:15",
-      image: "FIGMA",
-    },
-    {
-      id: 2,
-      symbol: "TSLA",
-      change: "+2.3%",
-      changeColor: "text-red-500",
-      headline: "테슬라, 사이버트럭 생산량 증가 발표... 주가 긍정적 영향",
-      source: "Reuters",
-      timestamp: "2025-09-05 08:30",
-      image: "TESLA",
-    },
-    {
-      id: 3,
-      symbol: "NVDA",
-      change: "+3.2%",
-      changeColor: "text-red-500",
-      headline: "엔비디아, AI 칩 수요 폭증으로 사상 최고 실적 기록",
-      source: "Bloomberg",
-      timestamp: "2025-09-05 07:45",
-      image: "NVIDIA",
-    },
-    {
-      id: 4,
-      symbol: "AAPL",
-      change: "-0.2%",
-      changeColor: "text-blue-500",
-      headline: "애플, 신형 아이폰 출시 지연 우려... 주가 소폭 하락",
-      source: "The Verge",
-      timestamp: "2025-09-04 18:00",
-      image: "APPLE",
-    },
-    {
-      id: 5,
-      symbol: "GOOGL",
-      change: "+1.2%",
-      changeColor: "text-red-500",
-      headline: "구글, 새로운 AI 검색 기능 공개... 시장 기대감 증폭",
-      source: "TechCrunch",
-      timestamp: "2025-09-04 16:30",
-      image: "GOOGLE",
-    },
-  ];
+	// 과거 모드 가격 캐시
+	const [histMap, setHistMap] = useState({}); // symbol -> { price, change, changePercent }
 
-  const handleGoBack = () => {
-    navigate("/");
-  };
+	// 날짜가 변경될 때마다 캐시 초기화
+	useEffect(() => {
+		if (isHistorical) {
+			setHistMap({});
+		}
+	}, [simDate?.year, simDate?.month, simDate?.day, isHistorical]);
 
-  const [openSimModal, setOpenSimModal] = useState(false);
-  const today = useMemo(() => new Date(), []);
-  const [simY, setSimY] = useState(today.getFullYear());
-  const [simM, setSimM] = useState(today.getMonth() + 1);
-  const [simD, setSimD] = useState(today.getDate());
-  const [errMsg, setErrMsg] = useState("");
 
-  const goToSimulator = () => {
-    setErrMsg("");
-    setOpenSimModal(true);
-  };
+	const handleGoBack = () => {
+		navigate("/");
+	};
 
-  const submitSim = () => {
-    const curYear = new Date().getFullYear();
-    const y = Math.max(1980, Math.min(curYear, Number(simY) || curYear));
-    const m = Math.max(1, Math.min(12, Number(simM) || 1));
-    const d = Math.max(1, Math.min(31, Number(simD) || 1));
-    if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d)) {
-      setErrMsg("유효한 날짜를 입력해주세요.");
-      return;
-    }
-    setOpenSimModal(false);
-    navigate(`/trade?y=${y}&m=${m}&d=${d}`);
-  };
+	const handleStockSelect = (stock) => {
+		navigate(`/stocks/${stock.symbol}`);
+	};
 
-  const handleStockSelect = (stock) => {
-    navigate(`/stocks/live/${stock.symbol}`);
-  };
+	const handleToggleFavorite = async (symbol) => {
+		if (!lastProfileId) {
+			alert('로그인이 필요합니다');
+			return;
+		}
+		
+		const success = await toggleWatchlist(symbol);
+		if (!success) {
+			alert('관심종목 토글에 실패했습니다');
+		}
+	};
 
-  const removeSelectedStock = (symbol) => {
-    setSelectedStocks(selectedStocks.filter((s) => s.symbol !== symbol));
-  };
+	// 주식 표시 데이터 계산 함수
+	const getStockDisplayData = (stock) => {
+		const hp = isHistorical ? histMap[stock.symbol] : null;
+		const priceText = isHistorical ? (hp?.price ?? '-') : (String(stock.price).startsWith('$') ? String(stock.price) : `$${String(stock.price)}`);
+		const changeText = isHistorical ? (hp?.change ?? '-') : String(stock.change ?? '');
+		const changePctText = isHistorical ? (hp?.changePercent ?? '-') : String(stock.changePercent ?? '');
+		const isUp = (isHistorical ? String(hp?.change || '').startsWith('+') : String(stock.change ?? '').includes("+"));
+		
+		return { priceText, changeText, changePctText, isUp };
+	};
 
-  const handleToggleFavorite = async (symbol) => {
-    if (!lastProfileId) {
-      alert('로그인이 필요합니다');
-      return;
-    }
-    
-    const success = await toggleWatchlist(symbol);
-    if (!success) {
-      alert('관심종목 토글에 실패했습니다');
-    }
-  };
+	// 주식 카드 컴포넌트
+	const StockCard = ({ stock, index, showFavorite = true }) => {
+		const { priceText, changeText, changePctText, isUp } = getStockDisplayData(stock);
+		
+		return (
+			<div
+				key={index}
+				onClick={() => handleStockSelect(stock)}
+				className="flex items-center justify-between p-3 bg-slate-800 rounded-xl cursor-pointer hover:bg-slate-700 transition-colors"
+			>
+				<div className="flex items-center gap-3">
+					<div className="w-10 h-10 bg-gray-100 rounded-lg flex items-center justify-center text-lg overflow-hidden">
+						<img
+							src={`https://financialmodelingprep.com/image-stock/${stock.symbol}.png`}
+							alt={stock.name}
+							className="w-full h-full object-cover"
+							onError={(e) => {
+								e.target.style.display = "none";
+								e.target.nextSibling.style.display = "flex";
+							}}
+						/>
+						<span className="text-gray-600 font-bold text-xs hidden">
+							{stock.symbol}
+						</span>
+					</div>
+					<div>
+						<h4 className="text-white font-medium">{stock.name}</h4>
+						<p className="text-gray-400 text-sm">{stock.symbol}</p>
+					</div>
+				</div>
+				<div className="flex items-center gap-3">
+					<div className="text-right">
+						<p className="text-white font-semibold text-lg">
+							{priceText}
+						</p>
+						<div className="flex items-center gap-1">
+							<p className={`text-sm font-medium ${isUp ? "text-red-500" : "text-blue-500"}`}>
+								{changeText}
+							</p>
+							<p className={`text-xs ${isUp ? "text-red-500" : "text-blue-500"}`}>
+								({changePctText})
+							</p>
+						</div>
+					</div>
+					{showFavorite && (
+						<button
+							onClick={(e) => {
+								e.stopPropagation();
+								handleToggleFavorite(stock.symbol);
+							}}
+							className="p-1 hover:bg-slate-600 rounded-full transition-colors"
+							disabled={watchlistLoading}
+						>
+							<Heart
+								className={`w-5 h-5 ${
+									isInWatchlist(stock.symbol)
+										? "text-red-500 fill-red-500"
+										: "text-gray-400"
+								}`}
+							/>
+						</button>
+					)}
+				</div>
+			</div>
+		);
+	};
 
-  // 필터링된 주식 목록
-  const filteredStocks = useMemo(() => {
-    let filtered = stocks.filter(
-      (stock) =>
-        stock.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        stock.symbol.toLowerCase().includes(searchQuery.toLowerCase())
-    );
+	// 필터링된 주식 목록
+	const filteredStocks = useMemo(() => {
+		let filtered = stocks.filter(
+			(stock) =>
+				stock.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+				stock.symbol.toLowerCase().includes(searchQuery.toLowerCase())
+		);
 
-    // 정렬 적용
-    switch (selectedFilter) {
-      case "이름":
-        filtered.sort((a, b) => a.name.localeCompare(b.name));
-        break;
-      case "가격":
-        filtered.sort((a, b) => {
-          const priceA = parseFloat(a.price.replace('$', '').replace(',', ''));
-          const priceB = parseFloat(b.price.replace('$', '').replace(',', ''));
-          return priceB - priceA; // 높은 가격순
-        });
-        break;
-      case "등락률":
-        filtered.sort((a, b) => {
-          const changeA = parseFloat(a.change.replace('%', ''));
-          const changeB = parseFloat(b.change.replace('%', ''));
-          return changeB - changeA; // 높은 등락률순
-        });
-        break;
-      default:
-        break;
-    }
+		// 정렬 적용 (표시값 기준 정렬: 과거 모드라면 histMap 값이 있으면 그 값으로)
+		switch (selectedFilter) {
+			case "이름":
+				filtered.sort((a, b) => a.name.localeCompare(b.name));
+				break;
+			case "가격":
+				filtered.sort((a, b) => {
+					const normalizePrice = (val) => parseFloat(String(val ?? '').replace('$', '').replace(',', '')) || 0;
+					const pa = isHistorical ? normalizePrice(histMap[a.symbol]?.price) : normalizePrice(a.price);
+					const pb = isHistorical ? normalizePrice(histMap[b.symbol]?.price) : normalizePrice(b.price);
+					return pb - pa;
+				});
+				break;
+			case "등락률":
+				filtered.sort((a, b) => {
+					const normalizePercent = (val) => parseFloat(String(val ?? '0').replace('%', '')) || 0;
+					const ca = isHistorical ? normalizePercent(histMap[a.symbol]?.changePercent) : normalizePercent(a.change);
+					const cb = isHistorical ? normalizePercent(histMap[b.symbol]?.changePercent) : normalizePercent(b.change);
+					return cb - ca;
+				});
+				break;
+			default:
+				break;
+		}
 
-    return filtered;
-  }, [stocks, searchQuery, selectedFilter]);
+		return filtered;
+	}, [stocks, searchQuery, selectedFilter, isHistorical, histMap]);
 
-  // 페이지네이션 계산
-  const totalPages = Math.ceil(filteredStocks.length / stocksPerPage);
-  const startIndex = (currentPage - 1) * stocksPerPage;
-  const endIndex = startIndex + stocksPerPage;
-  const currentStocks = filteredStocks.slice(startIndex, endIndex);
+	// 페이지네이션 계산
+	const totalPages = Math.ceil(filteredStocks.length / stocksPerPage);
+	const startIndex = (currentPage - 1) * stocksPerPage;
+	const endIndex = startIndex + stocksPerPage;
+	const currentStocks = filteredStocks.slice(startIndex, endIndex);
 
-  // 검색어 변경 시 첫 페이지로 이동
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [searchQuery, selectedFilter]);
+	// 현재 페이지 심볼들의 과거 가격 로드 트리거
+	useEffect(() => {
+		if (!isHistorical || !simDate) return;
+		const symbols = currentStocks.map(s => s.symbol).filter(Boolean);
+		if (symbols.length === 0) return;
+		
+		// 이미 캐시된 심볼들은 제외
+		const uncachedSymbols = symbols.filter(sym => !histMap[sym]);
+		if (uncachedSymbols.length === 0) return;
+		
+		const doFetch = async () => {
+			const base = new Date(Date.UTC(simDate.year, simDate.month - 1, simDate.day));
+			const selectedEpoch = Math.floor(base.getTime() / 1000);
+			const prevEpoch = selectedEpoch - 86400;
+			const curFrom = prevEpoch;
+			const curTo = selectedEpoch + 86400 * 7;
+			const prevFrom = prevEpoch - 86400 * 7;
+			const prevTo = prevEpoch;
+			const updates = {};
+			
+			await Promise.all(uncachedSymbols.map(async (sym) => {
+				try {
+					const [curRes, prevRes] = await Promise.all([
+						axios.get('/db/candles', { params: { ticker: sym, from: curFrom, to: curTo } }),
+						axios.get('/db/candles', { params: { ticker: sym, from: prevFrom, to: prevTo } }),
+					]);
+					const curT = curRes?.data?.t || [];
+					const curC = curRes?.data?.c || [];
+					let currentClose = null;
+					for (let i = 0; i < curT.length; i++) { if (curT[i] >= selectedEpoch) { currentClose = curC[i]; break; } }
+					const prevT = prevRes?.data?.t || [];
+					const prevC = prevRes?.data?.c || [];
+					let prevClose = null;
+					for (let i = prevT.length - 1; i >= 0; i--) { if (prevT[i] <= prevEpoch) { prevClose = prevC[i]; break; } }
+					if (typeof currentClose === 'number' && typeof prevClose === 'number') {
+						const chg = currentClose - prevClose;
+						const pct = prevClose !== 0 ? (chg / prevClose) * 100 : 0;
+						updates[sym] = { price: `$${currentClose.toFixed(2)}`, change: `${chg >= 0 ? '+' : ''}${chg.toFixed(2)}`, changePercent: `${pct >= 0 ? '+' : ''}${pct.toFixed(2)}%` };
+					} else {
+						updates[sym] = { price: '-', change: '-', changePercent: '-' };
+					}
+				} catch (_) {
+					updates[sym] = { price: '-', change: '-', changePercent: '-' };
+				}
+			}));
+			
+			if (Object.keys(updates).length > 0) setHistMap((prev) => ({ ...prev, ...updates }));
+		};
+		
+		doFetch();
+	}, [currentStocks, isHistorical, simDate?.year, simDate?.month, simDate?.day, histMap]);
 
-  // 페이지 이동 시 자동 갱신 제거 (스케줄러가 알아서 갱신)
+	// 검색어 변경 시 첫 페이지로 이동
+	useEffect(() => {
+		setCurrentPage(1);
+	}, [searchQuery, selectedFilter]);
 
-  return (
-    <div>
-      {/* 전체 콘텐츠 영역 */}
-      <div>
-        {/* 뒤로가기 버튼 */}
-        <div className="px-4 py-4">
-          <button
-            onClick={handleGoBack}
-            className="flex items-center gap-2 text-white hover:text-gray-300 transition-colors"
-          >
-            <ChevronLeft className="w-5 h-5" />
-            <span>뒤로가기</span>
-          </button>
-        </div>
 
-        {/* 페이지 제목 */}
-        <div className="px-4 py-2">
-          <div className="flex items-center justify-between">
-            <div>
-              <div className="flex items-center gap-4 text-xs text-gray-400 mt-1">
-                {lastUpdate && (
-                  <div className="flex items-center gap-1">
-                    <Clock className="w-3 h-3" />
-                    <span>마지막 업데이트: {lastUpdate.toLocaleTimeString()}</span>
-                  </div>
-                )}
-                <div className="flex items-center gap-1">
-                  <span>총 {stocks.length}개 주식</span>
-                  {filteredStocks.length !== stocks.length && (
-                    <span>(검색 결과: {filteredStocks.length}개)</span>
-                  )}
-                  {filteredStocks.length > stocksPerPage && (
-                    <span>(페이지 {currentPage}/{totalPages})</span>
-                  )}
-                </div>
-              </div>
-            </div>
-            <button
-              onClick={goToSimulator}
-              className="px-3 py-2 bg-blue-600 text-white rounded-lg text-sm hover:bg-blue-500"
-            >
-              시뮬레이터
-            </button>
-          </div>
-        </div>
+	return (
+		<div>
+			{/* 전체 콘텐츠 영역 */}
+			<div>
+				{/* 뒤로가기 버튼 */}
+				<div className="px-4 py-4">
+					<button
+						onClick={handleGoBack}
+						className="flex items-center gap-2 text-white hover:text-gray-300 transition-colors"
+					>
+						<ChevronLeft className="w-5 h-5" />
+						<span>뒤로가기</span>
+					</button>
+				</div>
 
-        {/* 시뮬레이터 날짜 선택 모달 */}
-        <Dialog open={openSimModal} onOpenChange={setOpenSimModal}>
-          <DialogContent className="bg-slate-900 text-white border border-slate-700">
-            <DialogHeader>
-              <DialogTitle>시뮬레이션 날짜 선택</DialogTitle>
-              <DialogDescription className="text-slate-400">
-                과거 특정 날짜로 돌아가 시뮬레이션을 시작합니다.
-              </DialogDescription>
-            </DialogHeader>
-            <div className="grid grid-cols-3 gap-3 mt-2">
-              <div>
-                <label className="text-sm text-slate-300">
-                  연도(1980~현재)
-                </label>
-                <input
-                  type="number"
-                  className="field w-full"
-                  value={simY}
-                  onChange={(e) => setSimY(e.target.value)}
-                  min={1980}
-                  max={new Date().getFullYear()}
-                />
-              </div>
-              <div>
-                <label className="text-sm text-slate-300">월(1~12)</label>
-                <input
-                  type="number"
-                  className="field w-full"
-                  value={simM}
-                  onChange={(e) => setSimM(e.target.value)}
-                  min={1}
-                  max={12}
-                />
-              </div>
-              <div>
-                <label className="text-sm text-slate-300">일(1~31)</label>
-                <input
-                  type="number"
-                  className="field w-full"
-                  value={simD}
-                  onChange={(e) => setSimD(e.target.value)}
-                  min={1}
-                  max={31}
-                />
-              </div>
-            </div>
-            {errMsg && (
-              <div className="text-red-400 text-sm mt-2">{errMsg}</div>
-            )}
-            <div className="flex gap-2 justify-end mt-4">
-              <button
-                className="px-3 py-2 bg-slate-800 rounded"
-                onClick={() => setOpenSimModal(false)}
-              >
-                취소
-              </button>
-              <button
-                className="px-3 py-2 bg-blue-600 rounded"
-                onClick={submitSim}
-              >
-                시작
-              </button>
-            </div>
-          </DialogContent>
-        </Dialog>
+				{/* 페이지 제목 */}
+				<div className="px-4 py-2">
+					<div className="flex items-center justify-between">
+						<div className="flex items-center gap-4 text-xs text-gray-400 mt-1">
+							{lastUpdate && (
+								<div className="flex items-center gap-1">
+									<Clock className="w-3 h-3" />
+									<span>마지막 업데이트: {lastUpdate.toLocaleTimeString()}</span>
+								</div>
+							)}
+							<div className="flex items-center gap-1">
+								<span>총 {stocks.length}개 주식</span>
+								{filteredStocks.length !== stocks.length && (
+									<span>(검색 결과: {filteredStocks.length}개)</span>
+								)}
+								{filteredStocks.length > stocksPerPage && (
+									<span>(페이지 {currentPage}/{totalPages})</span>
+								)}
+							</div>
+						</div>
+					</div>
+				</div>
 
-        {/* 탭 메뉴 */}
-        <div className="px-4 py-4">
-          <div className="flex bg-slate-800 rounded-xl p-1">
-            <button
-              onClick={() => setActiveTab("탐색")}
-              className={`flex-1 py-2 px-4 rounded-lg text-sm font-medium transition-colors ${
-                activeTab === "탐색"
-                  ? "bg-white text-black"
-                  : "text-gray-400 hover:text-white"
-              }`}
-            >
-              탐색
-            </button>
-            <button
-              onClick={() => setActiveTab("관심")}
-              className={`flex-1 py-2 px-4 rounded-lg text-sm font-medium transition-colors ${
-                activeTab === "관심"
-                  ? "bg-white text-black"
-                  : "text-gray-400 hover:text-white"
-              }`}
-            >
-              관심
-            </button>
-          </div>
-        </div>
+				{/* 탭 메뉴 */}
+				<div className="px-4 py-4">
+					<div className="flex bg-slate-800 rounded-xl p-1">
+						<button
+							onClick={() => setActiveTab("탐색")}
+							className={`flex-1 py-2 px-4 rounded-lg text-sm font-medium transition-colors ${
+								activeTab === "탐색"
+									? "bg-white text-black"
+									: "text-gray-400 hover:text-white"
+							}`}
+						>
+							탐색
+						</button>
+						<button
+							onClick={() => setActiveTab("관심")}
+							className={`flex-1 py-2 px-4 rounded-lg text-sm font-medium transition-colors ${
+								activeTab === "관심"
+									? "bg-white text-black"
+								: "text-gray-400 hover:text-white"
+							}`}
+						>
+							관심
+						</button>
+					</div>
+				</div>
 
-        {/* 탭에 따른 콘텐츠 */}
-        {activeTab === "탐색" ? (
-          <>
-            {/* 검색바 */}
-            <div className="px-4 py-2">
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400" />
-                <input
-                  type="text"
-                  placeholder="원하는 주식을 검색하세요"
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  className="w-full pl-10 pr-4 py-3 bg-slate-800 border border-slate-600 rounded-xl text-white placeholder-gray-400 focus:outline-none focus:border-blue-500"
-                />
-              </div>
-            </div>
+				{/* 탭에 따른 콘텐츠 */}
+				{activeTab === "탐색" ? (
+					<div>
+						{/* 검색바 */}
+						<div className="px-4 py-2">
+							<div className="relative">
+								<Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400" />
+								<input
+									type="text"
+									placeholder="원하는 주식을 검색하세요"
+									value={searchQuery}
+									onChange={(e) => setSearchQuery(e.target.value)}
+									className="w-full pl-10 pr-4 py-3 bg-slate-800 border border-slate-600 rounded-xl text-white placeholder-gray-400 focus:outline-none focus:border-blue-500"
+								/>
+							</div>
+						</div>
 
-            {/* 선택된 주식 태그들 */}
-            {selectedStocks.length > 0 && (
-              <div className="px-4 py-2">
-                <div className="flex flex-wrap gap-2">
-                  {selectedStocks.map((stock) => (
-                    <div
-                      key={stock.symbol}
-                      className="flex items-center gap-2 bg-blue-600 text-white px-3 py-1 rounded-full text-sm"
-                    >
-                      <span>
-                        {stock.symbol} {stock.change}
-                      </span>
-                      <button
-                        onClick={() => removeSelectedStock(stock.symbol)}
-                        className="hover:bg-blue-700 rounded-full p-1"
-                      >
-                        <X className="w-3 h-3" />
-                      </button>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
 
-            {/* 정렬 옵션 */}
-            <div className="px-4 py-2">
-              <div className="flex gap-2">
-                {["이름", "가격", "등락률"].map((option) => (
-                  <button
-                    key={option}
-                    onClick={() => setSelectedFilter(option)}
-                    className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
-                      selectedFilter === option
-                        ? "bg-white text-black border border-gray-300"
-                        : "bg-slate-800 text-gray-400 hover:text-white"
-                    }`}
-                  >
-                    {option}
-                  </button>
-                ))}
-              </div>
-            </div>
+						{/* 정렬 옵션 */}
+						<div className="px-4 py-2">
+							<div className="flex gap-2">
+								{["이름", "가격", "등락률"].map((option) => (
+									<button
+										key={option}
+										onClick={() => setSelectedFilter(option)}
+										className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+											selectedFilter === option
+												? "bg-white text-black border border-gray-300"
+												: "bg-slate-800 text-gray-400 hover:text-white"
+										}`}
+									>
+										{option}
+									</button>
+								))}
+							</div>
+						</div>
 
-            {/* 주식 목록 */}
-            <div className="px-4 py-2">
-              {error && (
-                <div className="mb-4 p-3 bg-red-900/20 border border-red-500/30 rounded-lg">
-                  <div className="flex items-center gap-2 text-red-400">
-                    <AlertCircle className="w-4 h-4" />
-                    <span className="text-sm">{error}</span>
-                  </div>
-                </div>
-              )}
+						{/* 주식 목록 */}
+						<div className="px-4 py-2">
+							{error && (
+								<div className="mb-4 p-3 bg-red-900/20 border border-red-500/30 rounded-lg">
+									<div className="flex items-center gap-2 text-red-400">
+										<AlertCircle className="w-4 h-4" />
+										<span className="text-sm">{error}</span>
+									</div>
+								</div>
+							)}
 
-              {loading ? (
-                <div className="space-y-2">
-                  {[...Array(5)].map((_, index) => (
-                    <div key={index} className="flex items-center justify-between p-3 bg-slate-800 rounded-xl animate-pulse">
-                      <div className="flex items-center gap-3">
-                        <div className="w-10 h-10 bg-slate-700 rounded-lg"></div>
-                        <div>
-                          <div className="h-4 bg-slate-700 rounded w-20 mb-2"></div>
-                          <div className="h-3 bg-slate-700 rounded w-16"></div>
-                        </div>
-                      </div>
-                      <div className="flex items-center gap-3">
-                        <div className="text-right">
-                          <div className="h-4 bg-slate-700 rounded w-16 mb-2"></div>
-                          <div className="h-3 bg-slate-700 rounded w-12"></div>
-                        </div>
-                        <div className="w-6 h-6 bg-slate-700 rounded-full"></div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <div className="space-y-2">
-                  {currentStocks.length === 0 ? (
-                    <div className="text-center py-8">
-                      <Search className="w-12 h-12 text-gray-400 mx-auto mb-4" />
-                      <p className="text-gray-400 text-sm">검색 결과가 없습니다</p>
-                      <p className="text-gray-500 text-xs mt-1">
-                        다른 검색어를 시도해보세요
-                      </p>
-                    </div>
-                  ) : (
-                    currentStocks.map((stock, index) => (
-                  <div
-                    key={index}
-                    onClick={() => handleStockSelect(stock)}
-                    className="flex items-center justify-between p-3 bg-slate-800 rounded-xl cursor-pointer hover:bg-slate-700 transition-colors"
-                  >
-                    <div className="flex items-center gap-3">
-                      <div className="w-10 h-10 bg-gray-100 rounded-lg flex items-center justify-center text-lg overflow-hidden">
-                        <img
-                          src={`https://financialmodelingprep.com/image-stock/${stock.symbol}.png`}
-                          alt={stock.name}
-                          className="w-full h-full object-cover"
-                          onError={(e) => {
-                            e.target.style.display = "none";
-                            e.target.nextSibling.style.display = "flex";
-                          }}
-                        />
-                        <span className="text-gray-600 font-bold text-xs hidden">
-                          {stock.symbol}
-                        </span>
-                      </div>
-                      <div>
-                        <h4 className="text-white font-medium">{stock.name}</h4>
-                        <p className="text-gray-400 text-sm">{stock.symbol}</p>
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-3">
-                      <div className="text-right">
-                        <p className="text-white font-semibold text-lg">
-                          {stock.price.startsWith('$') ? stock.price : `$${stock.price}`}
-                        </p>
-                        <div className="flex items-center gap-1">
-                          <p
-                            className={`text-sm font-medium ${
-                              stock.change.includes("+")
-                                ? "text-red-500"
-                                : "text-blue-500"
-                            }`}
-                          >
-                            {stock.change}
-                          </p>
-                          <p
-                            className={`text-xs ${
-                              stock.changePercent.includes("+")
-                                ? "text-red-500"
-                                : "text-blue-500"
-                            }`}
-                          >
-                            ({stock.changePercent})
-                          </p>
-                        </div>
-                      </div>
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleToggleFavorite(stock.symbol);
-                        }}
-                        className="p-1 hover:bg-slate-600 rounded-full transition-colors"
-                        disabled={watchlistLoading}
-                      >
-                        <Heart
-                          className={`w-5 h-5 ${
-                            isInWatchlist(stock.symbol)
-                              ? "text-red-500 fill-red-500"
-                              : "text-gray-400"
-                          }`}
-                        />
-                      </button>
-                    </div>
-                  </div>
-                    ))
-                  )}
-                </div>
-              )}
+							{loading ? (
+								<div className="space-y-2">{[...Array(5)].map((_, index) => (
+									<div key={index} className="flex items-center justify-between p-3 bg-slate-800 rounded-xl animate-pulse">
+										<div className="flex items-center gap-3">
+											<div className="w-10 h-10 bg-slate-700 rounded-lg"></div>
+											<div>
+												<div className="h-4 bg-slate-700 rounded w-20 mb-2"></div>
+												<div className="h-3 bg-slate-700 rounded w-16"></div>
+											</div>
+										</div>
+										<div className="flex items-center gap-3">
+											<div className="text-right">
+												<div className="h-4 bg-slate-700 rounded w-16 mb-2"></div>
+												<div className="h-3 bg-slate-700 rounded w-12"></div>
+											</div>
+											<div className="w-6 h-6 bg-slate-700 rounded-full"></div>
+										</div>
+									</div>
+								))}</div>
+							) : (
+								<div className="space-y-2">
+									{currentStocks.length === 0 ? (
+										<div className="text-center py-8">
+											<Search className="w-12 h-12 text-gray-400 mx-auto mb-4" />
+											<p className="text-gray-400 text-sm">검색 결과가 없습니다</p>
+											<p className="text-gray-500 text-xs mt-1">
+												다른 검색어를 시도해보세요
+											</p>
+										</div>
+									) : (
+										currentStocks.map((stock, index) => (
+											<StockCard key={index} stock={stock} index={index} />
+										))
+									)}
+								</div>
+							)}
 
-              {/* 페이지네이션 */}
-              {filteredStocks.length > stocksPerPage && (
-                <div className="mt-6 flex items-center justify-between">
-                  <div className="text-sm text-gray-400">
-                    {startIndex + 1}-{Math.min(endIndex, filteredStocks.length)} / {filteredStocks.length}개
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <button
-                      onClick={() => setCurrentPage(prev => Math.max(1, prev - 1))}
-                      disabled={currentPage === 1}
-                      className={`px-3 py-1 rounded-md text-sm ${
-                        currentPage === 1 
-                          ? 'bg-gray-700 text-gray-500 cursor-not-allowed' 
-                          : 'bg-slate-700 text-white hover:bg-slate-600'
-                      }`}
-                    >
-                      이전
-                    </button>
-                    <span className="text-sm text-gray-400">
-                      {currentPage} / {totalPages}
-                    </span>
-                    <button
-                      onClick={() => setCurrentPage(prev => Math.min(totalPages, prev + 1))}
-                      disabled={currentPage === totalPages}
-                      className={`px-3 py-1 rounded-md text-sm ${
-                        currentPage === totalPages 
-                          ? 'bg-gray-700 text-gray-500 cursor-not-allowed' 
-                          : 'bg-slate-700 text-white hover:bg-slate-600'
-                      }`}
-                    >
-                      다음
-                    </button>
-                  </div>
-                </div>
-              )}
+							{/* 페이지네이션 */}
+							{filteredStocks.length > stocksPerPage && (
+								<div className="mt-6 flex items-center justify-between">
+									<div className="text-sm text-gray-400">
+										{startIndex + 1}-{Math.min(endIndex, filteredStocks.length)} / {filteredStocks.length}개
+									</div>
+									<div className="flex items-center gap-2">
+										<button onClick={() => setCurrentPage(prev => Math.max(1, prev - 1))} disabled={currentPage === 1} className={`px-3 py-1 rounded-md text-sm ${currentPage === 1 ? 'bg-gray-700 text-gray-500 cursor-not-allowed' : 'bg-slate-700 text-white hover:bg-slate-600'}`}>이전</button>
+										<span className="text-sm text-gray-400">{currentPage} / {totalPages}</span>
+										<button onClick={() => setCurrentPage(prev => Math.min(totalPages, prev + 1))} disabled={currentPage === totalPages} className={`px-3 py-1 rounded-md text-sm ${currentPage === totalPages ? 'bg-gray-700 text-gray-500 cursor-not-allowed' : 'bg-slate-700 text-white hover:bg-slate-600'}`}>다음</button>
+									</div>
+								</div>
+							)}
 
-              {/* Redis 데이터 안내 */}
-              <div className="mt-4 p-3 bg-blue-900/20 border border-blue-500/30 rounded-lg">
-                <div className="flex items-center gap-2 text-blue-400 text-sm">
-                  <AlertCircle className="w-4 h-4" />
-                  <span>Redis 데이터: 백그라운드 스케줄러가 20분마다 자동 갱신하는 주식 데이터 | 갱신 없이 읽기만</span>
-                </div>
-              </div>
-            </div>
-          </>
-        ) : (
-          /* 관심종목 목록 */
-          <div className="px-4 py-2">
-            {watchlistError && (
-              <div className="mb-4 p-3 bg-red-900/20 border border-red-500/30 rounded-lg">
-                <div className="flex items-center gap-2 text-red-400">
-                  <AlertCircle className="w-4 h-4" />
-                  <span className="text-sm">{watchlistError}</span>
-                </div>
-              </div>
-            )}
-            
-            <div className="space-y-2">
-              {watchlistLoading ? (
-                <div className="space-y-2">
-                  {[...Array(3)].map((_, index) => (
-                    <div key={index} className="flex items-center justify-between p-3 bg-slate-800 rounded-xl animate-pulse">
-                      <div className="flex items-center gap-3">
-                        <div className="w-10 h-10 bg-slate-700 rounded-lg"></div>
-                        <div>
-                          <div className="h-4 bg-slate-700 rounded w-20 mb-2"></div>
-                          <div className="h-3 bg-slate-700 rounded w-16"></div>
-                        </div>
-                      </div>
-                      <div className="flex items-center gap-3">
-                        <div className="text-right">
-                          <div className="h-4 bg-slate-700 rounded w-16 mb-2"></div>
-                          <div className="h-3 bg-slate-700 rounded w-12"></div>
-                        </div>
-                        <div className="w-6 h-6 bg-slate-700 rounded-full"></div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              ) : watchlist.size === 0 ? (
-                <div className="text-center py-8">
-                  <Heart className="w-12 h-12 text-gray-400 mx-auto mb-4" />
-                  <p className="text-gray-400 text-sm">관심종목이 없습니다</p>
-                  <p className="text-gray-500 text-xs mt-1">
-                    탐색 탭에서 하트를 눌러 관심종목을 추가해보세요
-                  </p>
-                </div>
-              ) : (
-                stocks
-                  .filter((stock) => isInWatchlist(stock.symbol))
-                  .map((stock, index) => (
-                    <div
-                      key={index}
-                      className="flex items-center justify-between p-3 bg-slate-800 rounded-xl cursor-pointer hover:bg-slate-700 transition-colors"
-                      onClick={() => handleStockSelect(stock)}
-                    >
-                      <div className="flex items-center gap-3">
-                        <div className="w-10 h-10 bg-gray-100 rounded-lg flex items-center justify-center text-lg overflow-hidden">
-                          <img
-                            src={`https://financialmodelingprep.com/image-stock/${stock.symbol}.png`}
-                            alt={stock.name}
-                            className="w-full h-full object-cover"
-                            onError={(e) => {
-                              e.target.style.display = "none";
-                              e.target.nextSibling.style.display = "flex";
-                            }}
-                          />
-                          <span className="text-gray-600 font-bold text-xs hidden">
-                            {stock.symbol}
-                          </span>
-                        </div>
-                        <div>
-                          <h4 className="text-white font-medium">
-                            {stock.name}
-                          </h4>
-                          <p className="text-gray-400 text-sm">
-                            {stock.symbol}
-                          </p>
-                        </div>
-                      </div>
-                      <div className="flex items-center gap-3">
-                        <div className="text-right">
-                          <p className="text-white font-semibold text-lg">
-                            {stock.price.startsWith('$') ? stock.price : `$${stock.price}`}
-                          </p>
-                          <div className="flex items-center gap-1">
-                            <p
-                              className={`text-sm font-medium ${
-                                stock.change.includes("+")
-                                  ? "text-red-500"
-                                  : "text-blue-500"
-                              }`}
-                            >
-                              {stock.change}
-                            </p>
-                            <p
-                              className={`text-xs ${
-                                stock.changePercent && stock.changePercent.includes("+")
-                                  ? "text-red-500"
-                                  : "text-blue-500"
-                              }`}
-                            >
-                              ({stock.changePercent})
-                            </p>
-                          </div>
-                        </div>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handleToggleFavorite(stock.symbol);
-                          }}
-                          className="p-1 hover:bg-slate-600 rounded-full transition-colors"
-                          disabled={watchlistLoading}
-                        >
-                          <Heart className="w-5 h-5 text-red-500 fill-red-500" />
-                        </button>
-                      </div>
-                    </div>
-                  ))
-              )}
-            </div>
-          </div>
-        )}
-      </div>
-    </div>
-  );
+							{/* Redis 데이터 안내 */}
+							<div className="mt-4 p-3 bg-blue-900/20 border border-blue-500/30 rounded-lg">
+								<div className="flex items-center gap-2 text-blue-400 text-sm">
+									<AlertCircle className="w-4 h-4" />
+									<span>Redis 데이터: 백그라운드 스케줄러가 20분마다 자동 갱신하는 주식 데이터 | 갱신 없이 읽기만</span>
+								</div>
+							</div>
+						</div>
+					</div>
+				) : (
+					<div className="px-4 py-2">
+						{watchlistError && (
+							<div className="mb-4 p-3 bg-red-900/20 border border-red-500/30 rounded-lg">
+								<div className="flex items-center gap-2 text-red-400">
+									<AlertCircle className="w-4 h-4" />
+									<span className="text-sm">{watchlistError}</span>
+								</div>
+							</div>
+						)}
+						
+						<div className="space-y-2">
+							{watchlistLoading ? (
+								<div className="space-y-2">
+									{[...Array(3)].map((_, index) => (
+										<div key={index} className="flex items-center justify-between p-3 bg-slate-800 rounded-xl animate-pulse">
+											<div className="flex items-center gap-3">
+												<div className="w-10 h-10 bg-slate-700 rounded-lg"></div>
+												<div>
+													<div className="h-4 bg-slate-700 rounded w-20 mb-2"></div>
+													<div className="h-3 bg-slate-700 rounded w-16"></div>
+												</div>
+											</div>
+											<div className="flex items-center gap-3">
+												<div className="text-right">
+													<div className="h-4 bg-slate-700 rounded w-16 mb-2"></div>
+													<div className="h-3 bg-slate-700 rounded w-12"></div>
+												</div>
+												<div className="w-6 h-6 bg-slate-700 rounded-full"></div>
+											</div>
+										</div>
+									))}
+								</div>
+							) : watchlist.size === 0 ? (
+								<div className="text-center py-8">
+									<Heart className="w-12 h-12 text-gray-400 mx-auto mb-4" />
+									<p className="text-gray-400 text-sm">관심종목이 없습니다</p>
+									<p className="text-gray-500 text-xs mt-1">
+										탐색 탭에서 하트를 눌러 관심종목을 추가해보세요
+									</p>
+								</div>
+							) : (
+								stocks
+									.filter((stock) => isInWatchlist(stock.symbol))
+									.map((stock, index) => (
+										<StockCard key={index} stock={stock} index={index} showFavorite={true} />
+									))
+							)}
+						</div>
+					</div>
+				)}
+			</div>
+		</div>
+	);
 };
 
 export default Stocks;

--- a/src/pages/trade/StockLive.jsx
+++ b/src/pages/trade/StockLive.jsx
@@ -1,71 +1,138 @@
 import { useParams, useNavigate } from "react-router-dom";
 import { useEffect, useMemo, useState } from "react";
-import { TradeRealtimeWidget } from "../../components/UnifiedChart";
-import axiosInstance from "../../util/axiosInstance";
+import UnifiedChart from "../../components/UnifiedChart";
+import axios from "../../util/axiosInstance";
 
 export default function StockLive() {
-  const { symbol } = useParams();
-  const navigate = useNavigate();
-  const s = String(symbol || '').toUpperCase();
-  const [price, setPrice] = useState(null);
-  const [prevClose, setPrevClose] = useState(null);
-  const [err, setErr] = useState(null);
+	const { symbol } = useParams();
+	const navigate = useNavigate();
+	const s = String(symbol || '').toUpperCase();
 
-  const change = useMemo(() => {
-    if (!Number.isFinite(Number(price)) || !Number.isFinite(Number(prevClose))) return null;
-    return Number(price) - Number(prevClose);
-  }, [price, prevClose]);
-  const changePct = useMemo(() => {
-    if (!Number.isFinite(Number(price)) || !Number.isFinite(Number(prevClose)) || Number(prevClose) === 0) return null;
-    return (Number(price) / Number(prevClose) - 1) * 100;
-  }, [price, prevClose]);
+	// 프로필의 타임라인 정보: HomePage에서 localStorage("newProfile")에 저장됨
+	const profile = useMemo(() => {
+		try {
+			return JSON.parse(localStorage.getItem("newProfile") || "null");
+		} catch (_) { return null; }
+	}, []);
 
-  useEffect(() => {
-    let timer = null;
-    if (!s) { setErr('심볼 없음'); setPrice(null); setPrevClose(null); return; }
-    const fetchFromRedis = async () => {
-      try {
-        const res = await axiosInstance.get(`/market/redis/stock/${s}`);
-        const data = res?.data;
-        if (!data) { setErr('데이터 없음'); return; }
-        const cur = parseFloat(String(data.price || '').replace('$',''));
-        const chg = parseFloat(String(data.change || '').replace('+',''));
-        const prev = Number.isFinite(cur) && Number.isFinite(chg) ? (cur - chg) : null;
-        setPrice(Number.isFinite(cur) ? cur : null);
-        setPrevClose(Number.isFinite(prev) ? prev : null);
-        setErr(null);
-      } catch (_) {
-        setErr('Redis에서 가격을 불러오지 못했습니다.');
-      }
-    };
-    fetchFromRedis();
-    // 자동 갱신은 스케줄러에 맡김: 주기 요청 제거
-    return () => { if (timer) clearInterval(timer); };
-  }, [s]);
-  return (
-    <div className="container">
-      <div className="card" style={{ marginBottom: 12 }}>
-        <div className="row" style={{ justifyContent: 'space-between', width: '100%' }}>
-          <strong style={{ fontSize: 18 }}>{s || 'LIVE'}</strong>
-          <button className="btn" onClick={() => navigate(-1)}>뒤로</button>
-        </div>
-      </div>
-      <div className="card" style={{ marginBottom: 12 }}>
-        <div className="row" style={{ gap: 12 }}>
-          <span className="muted">현재가</span>
-          <strong>{Number.isFinite(Number(price)) ? Number(price).toFixed(2) : '-'}</strong>
-          <span className="muted">전일대비</span>
-          <span style={{ color: (change ?? 0) >= 0 ? '#26a69a' : '#ef5350' }}>
-            {Number.isFinite(Number(change)) ? `${change.toFixed(2)} (${Number(changePct).toFixed(2)}%)` : '-'}
-          </span>
-          {err && <span className="muted">{err}</span>}
-        </div>
-      </div>
-      <div style={{ height: 600 }}>
-        <TradeRealtimeWidget symbol={s} />
-      </div>
-    </div>
-  );
+	const timelineFrom = profile?.timelineFrom || null; // ISO string expected
+	const [simDate, setSimDate] = useState(() => {
+		if (!timelineFrom) return { year: null, month: null, day: null };
+		const d = new Date(timelineFrom);
+		if (Number.isNaN(d.getTime())) return { year: null, month: null, day: null };
+		return { year: d.getUTCFullYear(), month: d.getUTCMonth() + 1, day: d.getUTCDate() };
+	});
+
+	const isHistorical = Boolean(simDate.year && simDate.month && simDate.day);
+
+	const [price, setPrice] = useState(null);
+	const [prevClose, setPrevClose] = useState(null);
+	const [err, setErr] = useState(null);
+
+	const change = useMemo(() => {
+		if (!Number.isFinite(Number(price)) || !Number.isFinite(Number(prevClose))) return null;
+		return Number(price) - Number(prevClose);
+	}, [price, prevClose]);
+	const changePct = useMemo(() => {
+		if (!Number.isFinite(Number(price)) || !Number.isFinite(Number(prevClose)) || Number(prevClose) === 0) return null;
+		return (Number(price) / Number(prevClose) - 1) * 100;
+	}, [price, prevClose]);
+
+	// 가격/등락률 계산: 타임라인이 있으면 DB 캔들 기반, 없으면 Redis 실시간
+	useEffect(() => {
+		let active = true;
+		async function fetchHistorical() {
+			if (!s || !isHistorical) return;
+			try {
+				const base = new Date(Date.UTC(simDate.year, simDate.month - 1, simDate.day));
+				const selectedEpoch = Math.floor(base.getTime() / 1000);
+				const prevEpoch = selectedEpoch - 86400;
+				const curFrom = prevEpoch;
+				const curTo = selectedEpoch + 86400 * 7;
+				const prevFrom = prevEpoch - 86400 * 7;
+				const prevTo = prevEpoch;
+				const [curRes, prevRes] = await Promise.all([
+					axios.get('/db/candles', { params: { ticker: s, from: curFrom, to: curTo } }),
+					axios.get('/db/candles', { params: { ticker: s, from: prevFrom, to: prevTo } }),
+				]);
+				const curT = curRes?.data?.t || [];
+				const curO = curRes?.data?.o || [];
+				let currentOpen = null;
+				for (let i = 0; i < curT.length; i++) {
+					if (curT[i] >= selectedEpoch) { currentOpen = curO[i]; break; }
+				}
+				const prevT = prevRes?.data?.t || [];
+				const prevC = prevRes?.data?.c || [];
+				let prevCloseVal = null;
+				for (let i = prevT.length - 1; i >= 0; i--) {
+					if (prevT[i] <= prevEpoch) { prevCloseVal = prevC[i]; break; }
+				}
+				if (!active) return;
+				if (typeof currentOpen === 'number' && typeof prevCloseVal === 'number') {
+					setPrice(currentOpen);
+					setPrevClose(prevCloseVal);
+					setErr(null);
+				} else {
+					setPrice(null); setPrevClose(null); setErr('선택일 가격 데이터를 찾을 수 없습니다.');
+				}
+			} catch (_) {
+				if (!active) return;
+				setPrice(null); setPrevClose(null); setErr('DB에서 가격을 불러오지 못했습니다.');
+			}
+		}
+		async function fetchRealtime() {
+			if (!s || isHistorical) return;
+			try {
+				const res = await axios.get(`/market/redis/stock/${s}`);
+				const data = res?.data;
+				if (!data) { setErr('데이터 없음'); return; }
+				const cur = parseFloat(String(data.price || '').replace('$',''));
+				const chg = parseFloat(String(data.change || '').replace('+',''));
+				const prev = Number.isFinite(cur) && Number.isFinite(chg) ? (cur - chg) : null;
+				if (!active) return;
+				setPrice(Number.isFinite(cur) ? cur : null);
+				setPrevClose(Number.isFinite(prev) ? prev : null);
+				setErr(null);
+			} catch (_) {
+				if (!active) return;
+				setErr('Redis에서 가격을 불러오지 못했습니다.');
+			}
+		}
+		if (isHistorical) fetchHistorical(); else fetchRealtime();
+		return () => { active = false; };
+	}, [s, isHistorical, simDate]);
+
+	return (
+		<div className="container">
+			<div className="card" style={{ marginBottom: 12 }}>
+				<div className="row" style={{ justifyContent: 'space-between', width: '100%' }}>
+					<strong style={{ fontSize: 18 }}>{s || (isHistorical ? 'HIST' : 'LIVE')}</strong>
+					<button className="btn" onClick={() => navigate(-1)}>뒤로</button>
+				</div>
+			</div>
+			<div className="card" style={{ marginBottom: 12 }}>
+				<div className="row" style={{ gap: 12 }}>
+					<span className="muted">현재가</span>
+					<strong>{Number.isFinite(Number(price)) ? Number(price).toFixed(2) : '-'}</strong>
+					<span className="muted">전일대비</span>
+					<span style={{ color: (change ?? 0) >= 0 ? '#26a69a' : '#ef5350' }}>
+						{Number.isFinite(Number(change)) ? `${change.toFixed(2)} (${Number(changePct).toFixed(2)}%)` : '-'}
+					</span>
+					{err && <span className="muted">{err}</span>}
+				</div>
+			</div>
+			<div style={{ height: 600 }}>
+				<UnifiedChart
+					symbol={s}
+					defaultMode={isHistorical ? "historical" : "realtime"}
+					initialYear={isHistorical ? simDate.year : undefined}
+					initialMonth={isHistorical ? simDate.month : undefined}
+					initialDay={isHistorical ? simDate.day : undefined}
+					autoLoad={true}
+				/>
+			</div>
+		</div>
+	);
 }
 
 

--- a/src/pages/trade/StockLive.jsx
+++ b/src/pages/trade/StockLive.jsx
@@ -55,14 +55,14 @@ export default function StockLive() {
 					axios.get('/db/candles', { params: { ticker: s, from: curFrom, to: curTo } }),
 					axios.get('/db/candles', { params: { ticker: s, from: prevFrom, to: prevTo } }),
 				]);
-				const curT = curRes?.data?.t || [];
-				const curO = curRes?.data?.o || [];
+                const curT = curRes?.data?.timestamps || [];
+                const curO = curRes?.data?.opens || [];
 				let currentOpen = null;
 				for (let i = 0; i < curT.length; i++) {
 					if (curT[i] >= selectedEpoch) { currentOpen = curO[i]; break; }
 				}
-				const prevT = prevRes?.data?.t || [];
-				const prevC = prevRes?.data?.c || [];
+                const prevT = prevRes?.data?.timestamps || [];
+                const prevC = prevRes?.data?.closes || [];
 				let prevCloseVal = null;
 				for (let i = prevT.length - 1; i >= 0; i--) {
 					if (prevT[i] <= prevEpoch) { prevCloseVal = prevC[i]; break; }

--- a/src/pages/trade/TradePage.jsx
+++ b/src/pages/trade/TradePage.jsx
@@ -87,17 +87,17 @@ export default function TradePage() {
           axios.get('/db/candles', { params: { ticker: symbol, from: prevFrom, to: prevTo } }),
         ]);
 
-        const curT = curRes?.data?.t || [];
-        const curO = curRes?.data?.o || [];
-        const curD = curRes?.data?.d || [];
+        const curT = curRes?.data?.timestamps || [];
+        const curO = curRes?.data?.opens || [];
+        const curD = curRes?.data?.dates || [];
         // 선택일 당일 또는 이후 첫 거래일 찾기
         let currentOpen = null;
         for (let i = 0; i < curT.length; i++) {
           if (curT[i] >= selectedEpoch) { currentOpen = curO[i]; break; }
         }
 
-        const prevT = prevRes?.data?.t || [];
-        const prevC = prevRes?.data?.c || [];
+        const prevT = prevRes?.data?.timestamps || [];
+        const prevC = prevRes?.data?.closes || [];
         // 전일 이전 구간에서 마지막 거래일 종가
         let prevClose = null;
         for (let i = prevT.length - 1; i >= 0; i--) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #24  

## 📝작업 내용

> 1. 관심 종목 기능
    2. /stocks 페이지에서 등락률 기준으로 종목들을 확인할 수 있고, /home 에서는 실시간 급상승 top3 을 확인할 수 있음
    3. 실시간 타임라인은 계속 갱신되는 redis에서 데이터를, 과거 타임라인의 데이터는 DB 에서 가져오도록 구분했습니다.

### 스크린샷 (선택)

<img width="299" height="437" alt="image" src="https://github.com/user-attachments/assets/2a837d4e-2c23-4a1e-a7b4-b8acaa415e3d" />
<img width="293" height="506" alt="image" src="https://github.com/user-attachments/assets/cf926bb2-2d59-4c89-8fc0-98a3dc7a44dd" />
<img width="304" height="490" alt="image" src="https://github.com/user-attachments/assets/d75c6143-621f-4e33-b9c3-22ae85f9fa53" />

## 💬리뷰 요구사항(선택)

> 